### PR TITLE
tar treats Windows paths (D:\file.tar) as local files. Fixes #42

### DIFF
--- a/patoolib/programs/tar.py
+++ b/patoolib/programs/tar.py
@@ -19,14 +19,14 @@ import os
 
 def extract_tar (archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a TAR archive."""
-    cmdlist = [cmd, '--force-local', '--extract']
+    cmdlist = [cmd, '--extract']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive, '--directory', outdir])
     return cmdlist
 
 def list_tar (archive, compression, cmd, verbosity, interactive):
     """List a TAR archive."""
-    cmdlist = [cmd, '--force-local', '--list']
+    cmdlist = [cmd, '--list']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive])
     return cmdlist
@@ -35,7 +35,7 @@ test_tar = list_tar
 
 def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
     """Create a TAR archive."""
-    cmdlist = [cmd, '--force-local', '--create']
+    cmdlist = [cmd, '--create']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive, '--'])
     cmdlist.extend(filenames)
@@ -60,3 +60,5 @@ def add_tar_opts (cmdlist, compression, verbosity):
         cmdlist.extend(['--use-compress-program', program])
     if verbosity > 1:
         cmdlist.append('--verbose')
+    if progname == 'tar':
+        cmdlist.append('--force-local')

--- a/patoolib/programs/tar.py
+++ b/patoolib/programs/tar.py
@@ -19,14 +19,14 @@ import os
 
 def extract_tar (archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a TAR archive."""
-    cmdlist = [cmd, '--extract']
+    cmdlist = [cmd, '--force-local', '--extract']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive, '--directory', outdir])
     return cmdlist
 
 def list_tar (archive, compression, cmd, verbosity, interactive):
     """List a TAR archive."""
-    cmdlist = [cmd, '--list']
+    cmdlist = [cmd, '--force-local', '--list']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive])
     return cmdlist
@@ -35,7 +35,7 @@ test_tar = list_tar
 
 def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
     """Create a TAR archive."""
-    cmdlist = [cmd, '--create']
+    cmdlist = [cmd, '--force-local', '--create']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive, '--'])
     cmdlist.extend(filenames)


### PR DESCRIPTION
Apparently tar has capabilities for the extraction from remote locations
but in my (@yarikoptic) experience I have never ran into someone using it
since it requires some rmt server to be running etc.  So let's just favor
for files containing columns which are not generally forbidden.