### PR TITLE
BF(DOC): escape - in the manpage examples

### DIFF
--- a/doc/patool.1
+++ b/doc/patool.1
@@ -41,9 +41,9 @@ are supported natively and do not require helper applications to be
 installed.
 .SH EXAMPLES
   \fBpatool extract archive.zip otherarchive.rar\fP
-  \fBpatool --verbose test dist.tar.gz\fP
+  \fBpatool \-\-verbose test dist.tar.gz\fP
   \fBpatool list package.deb\fP
-  \fPpatool --verbose create myfiles.zip file1.txt dir/\fP
+  \fPpatool \-\-verbose create myfiles.zip file1.txt dir/\fP
   \fBpatool diff release1.0.tar.xz release2.0.zip\fP
   \fBpatool search "def urlopen" python-3.3.tar.gz\fP
   \fBpatool repack linux-2.6.33.tar.gz linux-2.6.33.tar.bz2\fP


### PR DESCRIPTION
Origin: Debian https://sources.debian.org/patches/patool/1.12-3/hyphen.patch/
