### PR TITLE
Add is_archive to API

### DIFF
--- a/doc/README.txt
+++ b/doc/README.txt
@@ -70,6 +70,7 @@ patoolib.create_archive("/path/to/myfiles.zip", ("file1.txt", "dir/"))
 patoolib.diff_archives("release1.0.tar.gz", "release2.0.zip")
 patoolib.search_archive("def urlopen", "python3.3.tar.gz")
 patoolib.repack_archive("linux-2.6.33.tar.gz", "linux-2.6.33.tar.bz2")
+patoolib.is_archive("package.deb")
 ```
 
 Test suite status

--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -299,6 +299,14 @@ def program_supports_compression (program, compression):
 
 from . import util
 
+def is_archive (filename):
+    """Detect if the file is a known archive."""
+    mime, compression = util.guess_mime(filename)
+    if mime in ArchiveMimetypes:
+            return True
+    return False
+
+
 def get_archive_format (filename):
     """Detect filename archive format and optional compression."""
     mime, compression = util.guess_mime(filename)


### PR DESCRIPTION
With is_archive you can test if a file is a known archive type.
The def returns True or False.

I don't know why your Travis fails, anyway it works for me.