### PR TITLE
Disable  7z password input prompt in non-interactive mode

### DIFF
--- a/patoolib/programs/p7rzip.py
+++ b/patoolib/programs/p7rzip.py
@@ -18,8 +18,28 @@
 7zr is a light executable supporting only the 7z archive format.
 """
 
-from .p7zip import \
-  extract_7z, \
-  list_7z, \
-  test_7z, \
-  create_7z
+from .p7zip import create_7z
+
+def extract_7z(archive, compression, cmd, verbosity, interactive, outdir):
+    """Extract a 7z archive."""
+    cmdlist = [cmd, 'x']
+    if not interactive:
+        cmdlist.append('-y')
+    cmdlist.extend(['-o%s' % outdir, '--', archive])
+    return cmdlist
+
+def list_7z(archive, compression, cmd, verbosity, interactive):
+    """List a 7z archive."""
+    cmdlist = [cmd, 'l']
+    if not interactive:
+        cmdlist.append('-y')
+    cmdlist.extend(['--', archive])
+    return cmdlist
+
+def test_7z(archive, compression, cmd, verbosity, interactive):
+    """Test a 7z archive."""
+    cmdlist = [cmd, 't']
+    if not interactive:
+        cmdlist.append('-y')
+    cmdlist.extend(['--', archive])
+    return cmdlist

--- a/patoolib/programs/p7zip.py
+++ b/patoolib/programs/p7zip.py
@@ -19,7 +19,7 @@ def extract_7z(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a 7z archive."""
     cmdlist = [cmd, 'x']
     if not interactive:
-        cmdlist.append('-y')
+        cmdlist.extend(['-p-', '-y'])
     cmdlist.extend(['-o%s' % outdir, '--', archive])
     return cmdlist
 

--- a/patoolib/programs/p7zip.py
+++ b/patoolib/programs/p7zip.py
@@ -29,7 +29,7 @@ def extract_7z_singlefile(archive, compression, cmd, verbosity, interactive, out
     which would cause errors with patool repack."""
     cmdlist = [cmd, 'e']
     if not interactive:
-        cmdlist.append('-y')
+        cmdlist.extend(['-p-', '-y'])
     cmdlist.extend(['-o%s' % outdir, '--', archive])
     return cmdlist
 
@@ -55,7 +55,7 @@ def list_7z (archive, compression, cmd, verbosity, interactive):
     """List a 7z archive."""
     cmdlist = [cmd, 'l']
     if not interactive:
-        cmdlist.append('-y')
+        cmdlist.extend(['-p-', '-y'])
     cmdlist.extend(['--', archive])
     return cmdlist
 
@@ -80,7 +80,7 @@ def test_7z (archive, compression, cmd, verbosity, interactive):
     """Test a 7z archive."""
     cmdlist = [cmd, 't']
     if not interactive:
-        cmdlist.append('-y')
+        cmdlist.extend(['-p-', '-y'])
     cmdlist.extend(['--', archive])
     return cmdlist
 


### PR DESCRIPTION
Fixes hang when attempting to extract password protected 7z archive in non-interactive mode, related to #55. Adds '-p-' to 7z cmdlist to skip password input prompt.