### PR TITLE
Fallback to other programs if a compression type isn't supported

### DIFF
--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -335,7 +335,11 @@ def program_supports_compression (program, compression):
       natively, else False.
     """
     if program in ('tar', ):
-        return compression in ('gzip', 'bzip2', 'compress')
+        if sys.platform == "win32":
+            # bzip2 is not supported natively in windows tar
+            return compression in ('gzip', 'compress')
+        else:
+            return compression in ('gzip', 'bzip2', 'compress')
     elif program == 'star':
         return compression in ('gzip', 'bzip2')
     elif program == 'bsdtar':

--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -398,6 +398,10 @@ def find_archive_program (format, command, program=None, password=None, compress
             if program == '7z' and format == 'rar' and not util.p7zip_supports_rar():
                 continue
             return exe
+
+    if compression is not None and compression in util.Encoding2Mime:
+        return find_archive_program(util.Encoding2Mime[compression], command, program)
+
     # no programs found
     raise util.PatoolError("could not find an executable program to %s format %s; candidates are (%s)," % (command, format, ",".join(programs)))
 

--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -333,7 +333,7 @@ def program_supports_compression (program, compression):
       natively, else False.
     """
     if program in ('tar', ):
-        return compression in ('gzip', 'bzip2', 'xz', 'lzip', 'compress', 'lzma') + py_lzma
+        return compression in ('gzip', 'bzip2', 'compress') + py_lzma
     elif program in ('star', 'bsdtar', 'py_tarfile'):
         return compression in ('gzip', 'bzip2') + py_lzma
     return False

--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -468,9 +468,11 @@ def check_program_compression(program, compression):
             # Check if compression is supported via an external program
             # Note that we expect the program name to be identical to the
             # compression type
-            comp_prog = util.find_program(compression)
-            if not comp_prog:
-                return False
+            if program in ('tar', 'star', 'bsdtar'):
+                comp_prog = util.find_program(compression)
+                if comp_prog:
+                    return True
+            return False
 
     return True
 

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -24,7 +24,7 @@ import tempfile
 import time
 import traceback
 import locale
-from . import configuration, ArchiveMimetypes, ArchiveCompressions, program_supports_compression
+from . import configuration, ArchiveMimetypes, ArchiveCompressions
 try:
     from shutil import which
 except ImportError:
@@ -313,12 +313,8 @@ def guess_mime_file (filename):
         elif mime2 in ArchiveMimetypes:
             mime = mime2
             encoding = get_file_mime_encoding(outparts)
-    # Only return mime and encoding if the given mime can natively support the encoding.
-    if program_supports_compression(ArchiveMimetypes.get(mime), encoding):
-        return mime, encoding
-    else:
-        # If encoding is None, default back to `mime`.
-        return Encoding2Mime.get(encoding, mime), None
+
+    return mime, encoding
 
 
 def guess_mime_file_mime (file_prog, filename):

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -152,9 +152,10 @@ class TestMime (unittest.TestCase):
 
     @needs_program('file')
     def test_nested_gzip (self):
-        # Ensure that a file that doesn't natively support encoding does not see the encoding
-        self.mime_test_file("t.rar.gz", "application/gzip")
-        self.mime_test_file("t.rar.gz.foo", "application/gzip")
+        # We won't extract this with rar, as it doesn't support archives wrapped in gzip
+        # compression, but we will recognize the archive as a gzip-wrapped rar-file
+        self.mime_test_file("t.rar.gz", "application/x-rar", "gzip")
+        self.mime_test_file("t.rar.gz.foo", "application/x-rar", "gzip")
 
     @needs_program('file')
     @needs_program('gzip')


### PR DESCRIPTION
This should fix #86, though I don't have an affected Windows machine to test it on, but I did test by renaming `/usr/bin/xz` on my machine (Linux), and it did fall back properly when attempting to extract a tar.xz file.

I also fixed how `program_supports_compression` works, as it `py_lzma` isn't a compression type, the compression types provided by `py_lzma` aren't applicable unless `py_tarfile` is the program used, and `bsdtar` supports `xz` and `lzma` natively regardless of whether `py_lzma` is present (or at least, patool expects that `bsdtar` will have `xz` and `lzma` support).

Admittedly the error produced when a program doesn't support a certain compression type now might be a little more cryptic, but I think the trade-off in usability is worth it (by actually being able to fallback to things like py_tarfile if tar doesn't support the compression type on platforms like windows which lack most compression utilities). Now it will say that it can't find a program that works, giving the list of programs that it tried to find, despite some of these potentially existing on the system, but just not supporting the compression type. It might be less confusing if it were logged that a program has been skipped due to an unsupported compression type, however I think it would be better to have configurable verbosity to avoid being unnecessarily verbose (e.g. using the logging module plus verbosity command line parameters, which do currently exist, but don't affect the `log_*` functions)