### PR TITLE
Fix flac CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
+dist: bionic
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 # whitelist
 branches:
   only:
@@ -12,7 +13,7 @@ branches:
 # install some archive programs
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq archmage arj bzip2 lbzip2 pbzip2 cabextract ncompress cpio bsdcpio lzop lcab p7zip p7zip-full zip unzip rpm2cpio binutils arc nomarch unalz lrzip bsdtar rzip zoo xdms lzip plzip clzip pdlzip sharutils flac unadf zoo zpaq libchm-bin genisoimage rpm
+  - sudo apt-get install -qq archmage arj bzip2 lbzip2 pbzip2 cabextract ncompress cpio bsdcpio lzop lcab p7zip p7zip-full zip unzip rpm2cpio binutils arc nomarch unalz lrzip bsdtar rzip xdms lzip plzip clzip pdlzip sharutils flac unadf zpaq libchm-bin genisoimage rpm
 # apt errors:
 #E: Package 'p7zip-rar' has no installation candidate
 #E: Package 'rar' has no installation candidate


### PR DESCRIPTION
Fixes flac-related CI failures as discussed in #83

I've also noticed that, while it would be useful to use a newer ubuntu distribution, the newest that also includes the zoo package is xenial (see [repology](https://repology.org/project/zoo/versions), and I think that's being used at the moment as the default on travis), and since xenial uses flac 1.3.1, the version with the bug, the only option that handles both is to downgrade to trusty with flac 1.3.0.

It could also be possible to get zoo installed on a newer distribution, either manually or using a ppa, but that would be more work. I suppose support for zoo could also be deprecated, but that's probably not ideal either.
