### PR TITLE
File error fix

### DIFF
--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -493,7 +493,10 @@ def shell_quote_nt (value):
 
 def stripext (filename):
     """Return the basename without extension of given filename."""
-    return os.path.splitext(os.path.basename(filename))[0]
+    basename, _ = os.path.splitext(os.path.basename(filename))
+    if basename.endswith(".tar"):
+        basename, _ = os.path.splitext(basename)
+    return basename
 
 
 def get_single_outfile (directory, archive, extension=""):

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -294,16 +294,15 @@ def guess_mime_file (filename):
         cmd = [file_prog, "--brief", "--mime", "--uncompress", filename]
         try:
             outparts = backtick(cmd).strip().split(";")
+            mime2 = outparts[0].split(" ", 1)[0]
         except OSError:
-            # ignore errors, as file(1) is only a fallback
-            return mime, encoding
-        mime2 = outparts[0].split(" ", 1)[0]
+            mime2 = None
         # Some file(1) implementations return an empty or unknown mime type
         # when the uncompressor program is not installed, other
         # implementation return the original file type.
         # The following detects both cases.
         if (mime2 in ('application/x-empty', 'application/octet-stream') or
-            mime2 in Mime2Encoding):
+            mime2 in Mime2Encoding or not mime2):
             # The uncompressor program file(1) uses is not installed
             # or is not able to uncompress.
             # Try to get mime information from the file extension.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -37,3 +37,10 @@ class UtilTest (unittest.TestCase):
         filename2 = os.path.join(parentdir, '.')
         self.assertFalse(util.is_same_file(filename1, filename2))
         self.assertFalse(util.is_same_filename(filename1, filename2))
+
+    def test_stripext(self):
+        self.assertTrue(util.stripext("bar.gz") == "bar")
+        self.assertTrue(util.stripext("foo/bar.tar.gz") == "bar")
+        self.assertTrue(util.stripext("foo/bartar.gz") == "bartar")
+        self.assertTrue(util.stripext("foo/bar.7z") == "bar")
+        self.assertTrue(util.stripext("foo/bar") == "bar")


### PR DESCRIPTION
I've pulled my fix for #94 out of #87 in the hopes that it might be merged sooner, given that #94 is a somewhat more significant bug than the less severe but more complicated bug I was trying to fix in #87.

I've also included a fix for the other problem reported in #94, that the default output directory for `tar.*` archives includes the `.tar` (noting that I made one logical change, as filenames which end in `tar` but not `.tar` shouldn't be modified).