### PR TITLE
remove spaces between function names and opening parentheses

### DIFF
--- a/patool
+++ b/patool
@@ -116,7 +116,7 @@ def run_recompress(args):
     return res
 
 
-def run_formats (args):
+def run_formats(args):
     """List supported and available archive formats."""
     patoolib.list_formats()
     return 0

--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -327,7 +327,7 @@ ProgramModules = {
 }
 
 
-def program_supports_compression (program, compression):
+def program_supports_compression(program, compression):
     """Decide if the given program supports the compression natively.
     @return: True iff the program supports the given compression format
       natively, else False.
@@ -341,7 +341,7 @@ def program_supports_compression (program, compression):
 
 from . import util
 
-def get_archive_format (filename):
+def get_archive_format(filename):
     """Detect filename archive format and optional compression."""
     mime, compression = util.guess_mime(filename)
     if not (mime or compression):
@@ -356,7 +356,7 @@ def get_archive_format (filename):
     return format, compression
 
 
-def check_archive_format (format, compression):
+def check_archive_format(format, compression):
     """Make sure format and compression is known."""
     if format not in ArchiveFormats:
         raise util.PatoolError("unknown archive format `%s'" % format)
@@ -364,7 +364,7 @@ def check_archive_format (format, compression):
         raise util.PatoolError("unkonwn archive compression `%s'" % compression)
 
 
-def find_archive_program (format, command, program=None, password=None):
+def find_archive_program(format, command, program=None, password=None):
     """Find suitable archive program for given format and mode."""
     commands = ArchivePrograms[format]
     programs = []
@@ -413,7 +413,7 @@ def _remove_command_without_password_support(programs, format, command):
     return programs_with_support
 
 
-def list_formats ():
+def list_formats():
     """Print information about available archive formats to stdout."""
     print("Archive programs of", App)
     print("Archive programs are searched in the following directories:")
@@ -462,7 +462,7 @@ def check_program_compression(archive, command, program, compression):
                 raise util.PatoolError(msg % (command, archive, compression))
 
 
-def move_outdir_orphan (outdir):
+def move_outdir_orphan(outdir):
     """Move a single file or directory inside outdir a level up.
     Never overwrite files.
     Return (True, outfile) if successful, (False, reason) if not."""
@@ -478,7 +478,7 @@ def move_outdir_orphan (outdir):
     return (False, "multiple files in root")
 
 
-def run_archive_cmdlist (archive_cmdlist, verbosity=0):
+def run_archive_cmdlist(archive_cmdlist, verbosity=0):
     """Run archive command."""
     # archive_cmdlist is a command list with optional keyword arguments
     if isinstance(archive_cmdlist, tuple):
@@ -488,18 +488,18 @@ def run_archive_cmdlist (archive_cmdlist, verbosity=0):
     return util.run_checked(cmdlist, verbosity=verbosity, **runkwargs)
 
 
-def make_file_readable (filename):
+def make_file_readable(filename):
     """Make file user readable if it is not a link."""
     if not os.path.islink(filename):
         util.set_mode(filename, stat.S_IRUSR)
 
 
-def make_dir_readable (filename):
+def make_dir_readable(filename):
     """Make directory user readable and executable."""
     util.set_mode(filename, stat.S_IRUSR|stat.S_IXUSR)
 
 
-def make_user_readable (directory):
+def make_user_readable(directory):
     """Make all files in given directory user readable. Also recurse into
     subdirectories."""
     for root, dirs, files in os.walk(directory, onerror=util.log_error):
@@ -509,7 +509,7 @@ def make_user_readable (directory):
             make_dir_readable(os.path.join(root, dirname))
 
 
-def cleanup_outdir (outdir, archive):
+def cleanup_outdir(outdir, archive):
     """Cleanup outdir after extraction and return target file name and
     result string."""
     make_user_readable(outdir)
@@ -610,7 +610,7 @@ def _handle_archive(archive, command, verbosity=0, interactive=True,
         run_archive_cmdlist(cmdlist, verbosity=verbosity)
 
 
-def get_archive_cmdlist_func (program, command, format):
+def get_archive_cmdlist_func(program, command, format):
     """Get the Python function that executes the given program."""
     # get python module for given archive program
     key = util.stripext(os.path.basename(program).lower())
@@ -643,13 +643,13 @@ def get_archive_cmdlist_func (program, command, format):
         raise util.PatoolError(msg)
 
 
-def rmtree_log_error (func, path, exc):
+def rmtree_log_error(func, path, exc):
     """Error function for shutil.rmtree(). Raises a PatoolError."""
     msg = "Error in %s(%s): %s" % (func.__name__, path, str(exc[1]))
     util.log_error(msg)
 
 
-def _diff_archives (archive1, archive2, verbosity=0, interactive=True):
+def _diff_archives(archive1, archive2, verbosity=0, interactive=True):
     """Show differences between two archives.
     @return 0 if archives are the same, else 1
     @raises: PatoolError on errors
@@ -687,7 +687,7 @@ def _search_archive(pattern, archive, verbosity=0, interactive=True, password=No
         shutil.rmtree(tmpdir, onerror=rmtree_log_error)
 
 
-def _repack_archive (archive1, archive2, verbosity=0, interactive=True, password=None):
+def _repack_archive(archive1, archive2, verbosity=0, interactive=True, password=None):
     """Repackage an archive to a different format."""
     format1, compression1 = get_archive_format(archive1)
     format2, compression2 = get_archive_format(archive2)
@@ -825,7 +825,7 @@ def search_archive(pattern, archive, verbosity=0, interactive=True, password=Non
     return res
 
 
-def repack_archive (archive, archive_new, verbosity=0, interactive=True, password=None):
+def repack_archive(archive, archive_new, verbosity=0, interactive=True, password=None):
     """Repack archive to different file and/or format."""
     util.check_existing_filename(archive)
     util.check_new_filename(archive_new)

--- a/patoolib/programs/__init__.py
+++ b/patoolib/programs/__init__.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from .. import util
 
-def extract_singlefile_standard (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_singlefile_standard(archive, compression, cmd, verbosity, interactive, outdir):
     """Standard routine to extract a singlefile archive (like gzip)."""
     cmdlist = [util.shell_quote(cmd)]
     if verbosity > 1:
@@ -26,7 +26,7 @@ def extract_singlefile_standard (archive, compression, cmd, verbosity, interacti
     return (cmdlist, {'shell': True})
 
 
-def test_singlefile_standard (archive, compression, cmd, verbosity, interactive):
+def test_singlefile_standard(archive, compression, cmd, verbosity, interactive):
     """Standard routine to test a singlefile archive (like gzip)."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -35,7 +35,7 @@ def test_singlefile_standard (archive, compression, cmd, verbosity, interactive)
     return cmdlist
 
 
-def create_singlefile_standard (archive, compression, cmd, verbosity, interactive, filenames):
+def create_singlefile_standard(archive, compression, cmd, verbosity, interactive, filenames):
     """Standard routine to create a singlefile archive (like gzip)."""
     cmdlist = [util.shell_quote(cmd)]
     if verbosity > 1:

--- a/patoolib/programs/ar.py
+++ b/patoolib/programs/ar.py
@@ -16,7 +16,7 @@
 """Archive commands for the ar program."""
 import os
 
-def extract_ar (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_ar(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a AR archive."""
     opts = 'x'
     if verbosity > 1:
@@ -24,7 +24,7 @@ def extract_ar (archive, compression, cmd, verbosity, interactive, outdir):
     cmdlist = [cmd, opts, os.path.abspath(archive)]
     return (cmdlist, {'cwd': outdir})
 
-def list_ar (archive, compression, cmd, verbosity, interactive):
+def list_ar(archive, compression, cmd, verbosity, interactive):
     """List a AR archive."""
     opts = 't'
     if verbosity > 1:
@@ -33,7 +33,7 @@ def list_ar (archive, compression, cmd, verbosity, interactive):
 
 test_ar = list_ar
 
-def create_ar (archive, compression, cmd, verbosity, interactive, filenames):
+def create_ar(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a AR archive."""
     opts = 'rc'
     if verbosity > 1:

--- a/patoolib/programs/arc.py
+++ b/patoolib/programs/arc.py
@@ -28,7 +28,7 @@ def _add_password_to_options(options, password):
     return options
 
 
-def extract_arc (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_arc(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract a ARC archive."""
     # Since extracted files will be placed in the current directory,
     # the cwd argument has to be the output directory.
@@ -37,7 +37,7 @@ def extract_arc (archive, compression, cmd, verbosity, interactive, outdir, pass
     return (cmdlist, {'cwd': outdir})
 
 
-def list_arc (archive, compression, cmd, verbosity, interactive, password=None):
+def list_arc(archive, compression, cmd, verbosity, interactive, password=None):
     """List a ARC archive."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -48,12 +48,12 @@ def list_arc (archive, compression, cmd, verbosity, interactive, password=None):
     return cmdlist
 
 
-def test_arc (archive, compression, cmd, verbosity, interactive, password=None):
+def test_arc(archive, compression, cmd, verbosity, interactive, password=None):
     """Test a ARC archive."""
     return [cmd, _add_password_to_options('t', password), archive]
 
 
-def create_arc (archive, compression, cmd, verbosity, interactive, filenames, password=None):
+def create_arc(archive, compression, cmd, verbosity, interactive, filenames, password=None):
     """Create a ARC archive."""
     cmdlist = [cmd, _add_password_to_options('a', password), archive]
     cmdlist.extend(filenames)

--- a/patoolib/programs/archmage.py
+++ b/patoolib/programs/archmage.py
@@ -18,7 +18,7 @@ import os
 from .. import util
 
 
-def extract_chm (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_chm(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a CHM archive."""
     # archmage can only extract in non-existing directories
     # so a nice dirname is created
@@ -27,6 +27,6 @@ def extract_chm (archive, compression, cmd, verbosity, interactive, outdir):
     return [cmd, '-x', os.path.abspath(archive), outfile]
 
 
-def test_chm (archive, compression, cmd, verbosity, interactive):
+def test_chm(archive, compression, cmd, verbosity, interactive):
     """Test a CHM archive."""
     return [cmd, '-d', os.path.abspath(archive)]

--- a/patoolib/programs/arj.py
+++ b/patoolib/programs/arj.py
@@ -27,7 +27,7 @@ def _maybe_add_password(cmdlist, password):
         cmdlist.append(_get_password_switch(password))
 
 
-def extract_arj (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_arj(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract an ARJ archive."""
     cmdlist = [cmd, 'x', '-r']
     _maybe_add_password(cmdlist, password)
@@ -37,7 +37,7 @@ def extract_arj (archive, compression, cmd, verbosity, interactive, outdir, pass
     return cmdlist
 
 
-def list_arj (archive, compression, cmd, verbosity, interactive, password=None):
+def list_arj(archive, compression, cmd, verbosity, interactive, password=None):
     """List an ARJ archive."""
     cmdlist = [cmd]
     _maybe_add_password(cmdlist, password)
@@ -51,7 +51,7 @@ def list_arj (archive, compression, cmd, verbosity, interactive, password=None):
     return cmdlist
 
 
-def test_arj (archive, compression, cmd, verbosity, interactive, password=None):
+def test_arj(archive, compression, cmd, verbosity, interactive, password=None):
     """Test an ARJ archive."""
     cmdlist = [cmd, 't', '-r']
     _maybe_add_password(cmdlist, password)
@@ -61,7 +61,7 @@ def test_arj (archive, compression, cmd, verbosity, interactive, password=None):
     return cmdlist
 
 
-def create_arj (archive, compression, cmd, verbosity, interactive, filenames, password=None):
+def create_arj(archive, compression, cmd, verbosity, interactive, filenames, password=None):
     """Create an ARJ archive."""
     cmdlist = [cmd, 'a', '-r']
     _maybe_add_password(cmdlist, password)

--- a/patoolib/programs/bzip2.py
+++ b/patoolib/programs/bzip2.py
@@ -20,7 +20,7 @@ from . import extract_singlefile_standard, test_singlefile_standard
 extract_bzip2 = extract_singlefile_standard
 test_bzip2 = test_singlefile_standard
 
-def create_bzip2 (archive, compression, cmd, verbosity, interactive, filenames):
+def create_bzip2(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a BZIP2 archive."""
     cmdlist = [util.shell_quote(cmd)]
     if verbosity > 1:

--- a/patoolib/programs/cabextract.py
+++ b/patoolib/programs/cabextract.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the cabextract program."""
 
-def extract_cab (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_cab(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a CAB archive."""
     cmdlist = [cmd, '-d', outdir]
     if verbosity > 0:
@@ -23,7 +23,7 @@ def extract_cab (archive, compression, cmd, verbosity, interactive, outdir):
     cmdlist.append(archive)
     return cmdlist
 
-def list_cab (archive, compression, cmd, verbosity, interactive):
+def list_cab(archive, compression, cmd, verbosity, interactive):
     """List a CAB archive."""
     cmdlist = [cmd, '-l']
     if verbosity > 0:
@@ -31,6 +31,6 @@ def list_cab (archive, compression, cmd, verbosity, interactive):
     cmdlist.append(archive)
     return cmdlist
 
-def test_cab (archive, compression, cmd, verbosity, interactive):
+def test_cab(archive, compression, cmd, verbosity, interactive):
     """Test a CAB archive."""
     return [cmd, '-t', archive]

--- a/patoolib/programs/chmlib.py
+++ b/patoolib/programs/chmlib.py
@@ -17,6 +17,6 @@
 import os
 
 
-def extract_chm (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_chm(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a CHM archive."""
     return [cmd, os.path.abspath(archive), outdir]

--- a/patoolib/programs/compress.py
+++ b/patoolib/programs/compress.py
@@ -17,7 +17,7 @@
 from .. import util
 
 
-def create_compress (archive, compression, cmd, verbosity, interactive, filenames):
+def create_compress(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a compressed archive."""
     cmdlist = [util.shell_quote(cmd)]
     if verbosity > 1:

--- a/patoolib/programs/cpio.py
+++ b/patoolib/programs/cpio.py
@@ -18,7 +18,7 @@ import os
 import sys
 from .. import util
 
-def extract_cpio (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_cpio(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a CPIO archive."""
     cmdlist = [util.shell_quote(cmd), '--extract', '--make-directories',
         '--preserve-modification-time']
@@ -31,7 +31,7 @@ def extract_cpio (archive, compression, cmd, verbosity, interactive, outdir):
     return (cmdlist, {'cwd': outdir, 'shell': True})
 
 
-def list_cpio (archive, compression, cmd, verbosity, interactive):
+def list_cpio(archive, compression, cmd, verbosity, interactive):
     """List a CPIO archive."""
     cmdlist = [cmd, '-i', '-t']
     if verbosity > 1:

--- a/patoolib/programs/dpkg.py
+++ b/patoolib/programs/dpkg.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the dpkg-deb program."""
 
-def extract_deb (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_deb(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a DEB archive."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -25,7 +25,7 @@ def extract_deb (archive, compression, cmd, verbosity, interactive, outdir):
     cmdlist.extend(['--', archive, outdir])
     return cmdlist
 
-def list_deb (archive, compression, cmd, verbosity, interactive):
+def list_deb(archive, compression, cmd, verbosity, interactive):
     """List a DEB archive."""
     return [cmd, '--contents', '--', archive]
 

--- a/patoolib/programs/flac.py
+++ b/patoolib/programs/flac.py
@@ -16,19 +16,19 @@
 """Archive commands for the flac program."""
 from .. import util
 
-def extract_flac (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_flac(archive, compression, cmd, verbosity, interactive, outdir):
     """Decompress a FLAC archive to a WAV file."""
     outfile = util.get_single_outfile(outdir, archive, extension=".wav")
     cmdlist = [cmd, '--decode', archive, '--output-name', outfile]
     return cmdlist
 
 
-def create_flac (archive, compression, cmd, verbosity, interactive, filenames):
+def create_flac(archive, compression, cmd, verbosity, interactive, filenames):
     """Compress a WAV file to a FLAC archive."""
     cmdlist = [cmd, filenames[0], '--best', '--output-name', archive]
     return cmdlist
 
 
-def test_flac (archive, compression, cmd, verbosity, interactive):
+def test_flac(archive, compression, cmd, verbosity, interactive):
     """Test a FLAC file."""
     return [cmd, '--test', archive]

--- a/patoolib/programs/genisoimage.py
+++ b/patoolib/programs/genisoimage.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the genisoimage program."""
 
-def create_iso (archive, compression, cmd, verbosity, interactive, filenames):
+def create_iso(archive, compression, cmd, verbosity, interactive, filenames):
     """Create an ISO archive."""
     # Use Joliet (-J) and Rock-Ridge (-r) format.
     cmdlist = [cmd, '-r', '-J']

--- a/patoolib/programs/gzip.py
+++ b/patoolib/programs/gzip.py
@@ -32,7 +32,7 @@ def create_gzip(archive, compression, cmd, verbosity, interactive, filenames):
     return (cmdlist, {'shell': True})
 
 
-def list_gzip (archive, compression, cmd, verbosity, interactive):
+def list_gzip(archive, compression, cmd, verbosity, interactive):
     """List a GZIP archive."""
     cmdlist = [cmd]
     if verbosity > 0:

--- a/patoolib/programs/isoinfo.py
+++ b/patoolib/programs/isoinfo.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the isoinfo program."""
 
-def list_iso (archive, compression, cmd, verbosity, interactive):
+def list_iso(archive, compression, cmd, verbosity, interactive):
     """List an ISO archive."""
     # Use Joliet (-J) and Rock-Ridge (-R) options.
     return [cmd, '-l', '-R', '-J', '-i', archive]

--- a/patoolib/programs/lcab.py
+++ b/patoolib/programs/lcab.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the lcab program."""
 
-def create_cab (archive, compression, cmd, verbosity, interactive, filenames):
+def create_cab(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a CAB archive."""
     cmdlist = [cmd, '-r']
     cmdlist.extend(filenames)

--- a/patoolib/programs/lha.py
+++ b/patoolib/programs/lha.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the lha program."""
 
-def extract_lzh (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_lzh(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a LZH archive."""
     opts = 'x'
     if verbosity > 1:
@@ -23,7 +23,7 @@ def extract_lzh (archive, compression, cmd, verbosity, interactive, outdir):
     opts += "w=%s" % outdir
     return [cmd, opts, archive]
 
-def list_lzh (archive, compression, cmd, verbosity, interactive):
+def list_lzh(archive, compression, cmd, verbosity, interactive):
     """List a LZH archive."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -33,14 +33,14 @@ def list_lzh (archive, compression, cmd, verbosity, interactive):
     cmdlist.append(archive)
     return cmdlist
 
-def test_lzh (archive, compression, cmd, verbosity, interactive):
+def test_lzh(archive, compression, cmd, verbosity, interactive):
     """Test a LZH archive."""
     opts = 't'
     if verbosity > 1:
         opts += 'v'
     return [cmd, opts, archive]
 
-def create_lzh (archive, compression, cmd, verbosity, interactive, filenames):
+def create_lzh(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a LZH archive."""
     opts = 'a'
     if verbosity > 1:

--- a/patoolib/programs/lrzip.py
+++ b/patoolib/programs/lrzip.py
@@ -17,7 +17,7 @@
 import os
 from .. import util
 
-def extract_lrzip (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_lrzip(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a LRZIP archive."""
     cmdlist = [cmd, '-d']
     if verbosity > 1:
@@ -26,7 +26,7 @@ def extract_lrzip (archive, compression, cmd, verbosity, interactive, outdir):
     cmdlist.extend(["-o", outfile, os.path.abspath(archive)])
     return cmdlist
 
-def test_lrzip (archive, compression, cmd, verbosity, interactive):
+def test_lrzip(archive, compression, cmd, verbosity, interactive):
     """Test a LRZIP archive."""
     cmdlist = [cmd, '-t']
     if verbosity > 1:
@@ -34,7 +34,7 @@ def test_lrzip (archive, compression, cmd, verbosity, interactive):
     cmdlist.append(archive)
     return cmdlist
 
-def create_lrzip (archive, compression, cmd, verbosity, interactive, filenames):
+def create_lrzip(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a LRZIP archive."""
     cmdlist = [cmd, '-o', archive]
     if verbosity > 1:

--- a/patoolib/programs/lzop.py
+++ b/patoolib/programs/lzop.py
@@ -20,7 +20,7 @@ from . import extract_singlefile_standard
 extract_lzop = extract_singlefile_standard
 
 
-def list_lzop (archive, compression, cmd, verbosity, interactive):
+def list_lzop(archive, compression, cmd, verbosity, interactive):
     """List a LZOP archive."""
     cmdlist = [cmd, '--list']
     if verbosity > 1:
@@ -28,7 +28,7 @@ def list_lzop (archive, compression, cmd, verbosity, interactive):
     cmdlist.extend(['--', archive])
     return cmdlist
 
-def test_lzop (archive, compression, cmd, verbosity, interactive):
+def test_lzop(archive, compression, cmd, verbosity, interactive):
     """Test a LZOP archive."""
     cmdlist = [cmd, '--test']
     if verbosity > 1:
@@ -36,7 +36,7 @@ def test_lzop (archive, compression, cmd, verbosity, interactive):
     cmdlist.extend(['--', archive])
     return cmdlist
 
-def create_lzop (archive, compression, cmd, verbosity, interactive, filenames):
+def create_lzop(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a LZOP archive."""
     cmdlist = [cmd]
     if verbosity > 1:

--- a/patoolib/programs/mac.py
+++ b/patoolib/programs/mac.py
@@ -16,13 +16,13 @@
 """Archive commands for the MAC.exe program."""
 from .. import util
 
-def extract_ape (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_ape(archive, compression, cmd, verbosity, interactive, outdir):
     """Decompress an APE archive to a WAV file."""
     outfile = util.get_single_outfile(outdir, archive, extension=".wav")
     return [cmd, archive, outfile, '-d']
 
 
-def create_ape (archive, compression, cmd, verbosity, interactive, filenames):
+def create_ape(archive, compression, cmd, verbosity, interactive, filenames):
     """Compress a WAV file to an APE archive."""
     cmdlist = [cmd]
     cmdlist.extend(filenames)
@@ -31,6 +31,6 @@ def create_ape (archive, compression, cmd, verbosity, interactive, filenames):
     return cmdlist
 
 
-def test_ape (archive, compression, cmd, verbosity, interactive):
+def test_ape(archive, compression, cmd, verbosity, interactive):
     """Test an APE archive."""
     return [cmd, archive, '-v']

--- a/patoolib/programs/nomarch.py
+++ b/patoolib/programs/nomarch.py
@@ -16,14 +16,14 @@
 """Archive commands for the nomarch program."""
 import os
 
-def extract_arc (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_arc(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract an ARC archive."""
     # Since extracted files will be placed in the current directory,
     # the cwd argument has to be the output directory.
     cmdlist = [cmd, os.path.abspath(archive)]
     return (cmdlist, {'cwd': outdir})
 
-def list_arc (archive, compression, cmd, verbosity, interactive):
+def list_arc(archive, compression, cmd, verbosity, interactive):
     """List an ARC archive."""
     cmdlist = [cmd, '-l']
     if verbosity > 1:
@@ -31,6 +31,6 @@ def list_arc (archive, compression, cmd, verbosity, interactive):
     cmdlist.append(archive)
     return cmdlist
 
-def test_arc (archive, compression, cmd, verbosity, interactive):
+def test_arc(archive, compression, cmd, verbosity, interactive):
     """Test an ARC archive."""
     return [cmd, '-t', archive]

--- a/patoolib/programs/p7zip.py
+++ b/patoolib/programs/p7zip.py
@@ -57,7 +57,7 @@ extract_zip = \
   extract_vhd = \
   extract_7z
 
-def list_7z (archive, compression, cmd, verbosity, interactive, password=None):
+def list_7z(archive, compression, cmd, verbosity, interactive, password=None):
     """List a 7z archive."""
     cmdlist = [cmd, 'l']
     if not interactive:
@@ -83,7 +83,7 @@ list_bzip2 = \
   list_7z
 
 
-def test_7z (archive, compression, cmd, verbosity, interactive, password=None):
+def test_7z(archive, compression, cmd, verbosity, interactive, password=None):
     """Test a 7z archive."""
     cmdlist = [cmd, 't']
     if not interactive:

--- a/patoolib/programs/py_bz2.py
+++ b/patoolib/programs/py_bz2.py
@@ -24,7 +24,7 @@ except ImportError:
 # read in 1MB chunks
 READ_SIZE_BYTES = 1024*1024
 
-def extract_bzip2 (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_bzip2(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a BZIP2 archive with the bz2 Python module."""
     targetname = util.get_single_outfile(outdir, archive)
     try:
@@ -40,7 +40,7 @@ def extract_bzip2 (archive, compression, cmd, verbosity, interactive, outdir):
     return None
 
 
-def create_bzip2 (archive, compression, cmd, verbosity, interactive, filenames):
+def create_bzip2(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a BZIP2 archive with the bz2 Python module."""
     if len(filenames) > 1:
         raise util.PatoolError('multi-file compression not supported in Python bz2')

--- a/patoolib/programs/py_echo.py
+++ b/patoolib/programs/py_echo.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 from .. import util
 
 
-def list_bzip2 (archive, compression, cmd, verbosity, interactive):
+def list_bzip2(archive, compression, cmd, verbosity, interactive):
     """List a BZIP2 archive."""
     return stripext(cmd, archive, verbosity)
 
@@ -31,7 +31,7 @@ list_compress = \
   list_rzip = \
   list_bzip2
 
-def list_ape (archive, compression, cmd, verbosity, interactive):
+def list_ape(archive, compression, cmd, verbosity, interactive):
     """List an APE archive."""
     return stripext(cmd, archive, verbosity, extension=".wav")
 
@@ -39,7 +39,7 @@ list_shn = \
   list_flac = \
   list_ape
 
-def stripext (cmd, archive, verbosity, extension=""):
+def stripext(cmd, archive, verbosity, extension=""):
     """Print the name without suffix."""
     if verbosity >= 0:
         print(util.stripext(archive)+extension)

--- a/patoolib/programs/py_gzip.py
+++ b/patoolib/programs/py_gzip.py
@@ -21,7 +21,7 @@ from .. import util
 
 READ_SIZE_BYTES = 1024*1024
 
-def extract_gzip (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_gzip(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a GZIP archive with the gzip Python module."""
     targetname = util.get_single_outfile(outdir, archive)
     try:
@@ -37,7 +37,7 @@ def extract_gzip (archive, compression, cmd, verbosity, interactive, outdir):
     return None
 
 
-def create_gzip (archive, compression, cmd, verbosity, interactive, filenames):
+def create_gzip(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a GZIP archive with the gzip Python module."""
     if len(filenames) > 1:
         raise util.PatoolError('multi-file compression not supported in Python gzip')

--- a/patoolib/programs/py_tarfile.py
+++ b/patoolib/programs/py_tarfile.py
@@ -20,7 +20,7 @@ import tarfile
 READ_SIZE_BYTES = 1024*1024
 
 
-def list_tar (archive, compression, cmd, verbosity, interactive):
+def list_tar(archive, compression, cmd, verbosity, interactive):
     """List a TAR archive with the tarfile Python module."""
     try:
         with tarfile.open(archive) as tfile:
@@ -32,7 +32,7 @@ def list_tar (archive, compression, cmd, verbosity, interactive):
 
 test_tar = list_tar
 
-def extract_tar (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_tar(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a TAR archive with the tarfile Python module."""
     try:
         with tarfile.open(archive) as tfile:
@@ -43,7 +43,7 @@ def extract_tar (archive, compression, cmd, verbosity, interactive, outdir):
     return None
 
 
-def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
+def create_tar(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a TAR archive with the tarfile Python module."""
     mode = get_tar_mode(compression)
     try:
@@ -56,7 +56,7 @@ def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
     return None
 
 
-def get_tar_mode (compression):
+def get_tar_mode(compression):
     """Determine tarfile open mode according to the given compression."""
     if compression == 'gzip':
         return 'w:gz'

--- a/patoolib/programs/py_zipfile.py
+++ b/patoolib/programs/py_zipfile.py
@@ -66,7 +66,7 @@ def create_zip(archive, compression, cmd, verbosity, interactive, filenames):
     return None
 
 
-def write_directory (zfile, directory):
+def write_directory(zfile, directory):
     """Write recursively all directories and filenames to zipfile instance."""
     for dirpath, dirnames, filenames in os.walk(directory):
         zfile.write(dirpath)

--- a/patoolib/programs/rar.py
+++ b/patoolib/programs/rar.py
@@ -16,7 +16,7 @@
 """Archive commands for the rar program."""
 import os
 
-def extract_rar (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_rar(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract a RAR archive."""
     cmdlist = [cmd, 'x']
     if not interactive:
@@ -26,7 +26,7 @@ def extract_rar (archive, compression, cmd, verbosity, interactive, outdir, pass
     cmdlist.extend(['--', os.path.abspath(archive)])
     return (cmdlist, {'cwd': outdir})
 
-def list_rar (archive, compression, cmd, verbosity, interactive, password=None):
+def list_rar(archive, compression, cmd, verbosity, interactive, password=None):
     """List a RAR archive."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -40,7 +40,7 @@ def list_rar (archive, compression, cmd, verbosity, interactive, password=None):
     cmdlist.extend(['--', archive])
     return cmdlist
 
-def test_rar (archive, compression, cmd, verbosity, interactive, password=None):
+def test_rar(archive, compression, cmd, verbosity, interactive, password=None):
     """Test a RAR archive."""
     cmdlist = [cmd, 't']
     if not interactive:
@@ -50,7 +50,7 @@ def test_rar (archive, compression, cmd, verbosity, interactive, password=None):
     cmdlist.extend(['--', archive])
     return cmdlist
 
-def create_rar (archive, compression, cmd, verbosity, interactive, filenames, password=None):
+def create_rar(archive, compression, cmd, verbosity, interactive, filenames, password=None):
     """Create a RAR archive."""
     cmdlist = [cmd, 'a']
     if not interactive:

--- a/patoolib/programs/rpm.py
+++ b/patoolib/programs/rpm.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the rpm program."""
 
-def list_rpm (archive, compression, cmd, verbosity, interactive):
+def list_rpm(archive, compression, cmd, verbosity, interactive):
     """List a RPM archive."""
     cmdlist = [cmd, '-q', '-l']
     if verbosity > 1:
@@ -23,7 +23,7 @@ def list_rpm (archive, compression, cmd, verbosity, interactive):
     cmdlist.extend(['-p', '--', archive])
     return cmdlist
 
-def test_rpm (archive, compression, cmd, verbosity, interactive):
+def test_rpm(archive, compression, cmd, verbosity, interactive):
     """Test a RPM archive."""
     cmdlist = [cmd, 'V']
     if verbosity > 1:

--- a/patoolib/programs/rpm2cpio.py
+++ b/patoolib/programs/rpm2cpio.py
@@ -17,7 +17,7 @@
 import os
 from .. import util
 
-def extract_rpm (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_rpm(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a RPM archive."""
     # also check cpio
     cpio = util.find_program("cpio")

--- a/patoolib/programs/rzip.py
+++ b/patoolib/programs/rzip.py
@@ -16,7 +16,7 @@
 """Archive commands for the rzip program."""
 from .. import util
 
-def extract_rzip (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_rzip(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract an RZIP archive."""
     cmdlist = [cmd, '-d', '-k']
     if verbosity > 1:
@@ -25,7 +25,7 @@ def extract_rzip (archive, compression, cmd, verbosity, interactive, outdir):
     cmdlist.extend(["-o", outfile, archive])
     return cmdlist
 
-def create_rzip (archive, compression, cmd, verbosity, interactive, filenames):
+def create_rzip(archive, compression, cmd, verbosity, interactive, filenames):
     """Create an RZIP archive."""
     cmdlist = [cmd, '-k', '-9', '-o', archive]
     if verbosity > 1:

--- a/patoolib/programs/shar.py
+++ b/patoolib/programs/shar.py
@@ -16,7 +16,7 @@
 """Archive commands for the shar program."""
 from .. import util
 
-def create_shar (archive, compression, cmd, verbosity, interactive, filenames):
+def create_shar(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a SHAR archive."""
     cmdlist = [util.shell_quote(cmd)]
     cmdlist.extend([util.shell_quote(x) for x in filenames])

--- a/patoolib/programs/shorten.py
+++ b/patoolib/programs/shorten.py
@@ -16,7 +16,7 @@
 """Archive commands for the shorten program."""
 from .. import util
 
-def extract_shn (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_shn(archive, compression, cmd, verbosity, interactive, outdir):
     """Decompress a SHN archive to a WAV file."""
     cmdlist = [util.shell_quote(cmd)]
     outfile = util.get_single_outfile(outdir, archive, extension=".wav")
@@ -25,7 +25,7 @@ def extract_shn (archive, compression, cmd, verbosity, interactive, outdir):
     return (cmdlist, {'shell': True})
 
 
-def create_shn (archive, compression, cmd, verbosity, interactive, filenames):
+def create_shn(archive, compression, cmd, verbosity, interactive, filenames):
     """Compress a WAV file to a SHN archive."""
     if len(filenames) > 1:
         raise util.PatoolError("multiple filenames for shorten not supported")

--- a/patoolib/programs/star.py
+++ b/patoolib/programs/star.py
@@ -16,14 +16,14 @@
 """Archive commands for the star program."""
 from .tar import add_tar_opts as add_star_opts
 
-def extract_tar (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_tar(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a TAR archive."""
     cmdlist = [cmd, '-x']
     add_star_opts(cmdlist, compression, verbosity)
     cmdlist.extend(['-C', outdir, 'file=%s' % archive])
     return cmdlist
 
-def list_tar (archive, compression, cmd, verbosity, interactive):
+def list_tar(archive, compression, cmd, verbosity, interactive):
     """List a TAR archive."""
     cmdlist = [cmd, '-n']
     add_star_opts(cmdlist, compression, verbosity)
@@ -32,7 +32,7 @@ def list_tar (archive, compression, cmd, verbosity, interactive):
 
 test_tar = list_tar
 
-def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
+def create_tar(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a TAR archive."""
     cmdlist = [cmd, '-c']
     add_star_opts(cmdlist, compression, verbosity)

--- a/patoolib/programs/tar.py
+++ b/patoolib/programs/tar.py
@@ -17,14 +17,14 @@
 import os
 
 
-def extract_tar (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_tar(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a TAR archive."""
     cmdlist = [cmd, '--extract']
     add_tar_opts(cmdlist, compression, verbosity)
     cmdlist.extend(["--file", archive, '--directory', outdir])
     return cmdlist
 
-def list_tar (archive, compression, cmd, verbosity, interactive):
+def list_tar(archive, compression, cmd, verbosity, interactive):
     """List a TAR archive."""
     cmdlist = [cmd, '--list']
     add_tar_opts(cmdlist, compression, verbosity)
@@ -33,7 +33,7 @@ def list_tar (archive, compression, cmd, verbosity, interactive):
 
 test_tar = list_tar
 
-def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
+def create_tar(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a TAR archive."""
     cmdlist = [cmd, '--create']
     add_tar_opts(cmdlist, compression, verbosity)
@@ -41,7 +41,7 @@ def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
     cmdlist.extend(filenames)
     return cmdlist
 
-def add_tar_opts (cmdlist, compression, verbosity):
+def add_tar_opts(cmdlist, compression, verbosity):
     """Add tar options to cmdlist."""
     progname = os.path.basename(cmdlist[0])
     if compression == 'gzip':

--- a/patoolib/programs/unace.py
+++ b/patoolib/programs/unace.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the unace program."""
 
-def extract_ace (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_ace(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract an ACE archive."""
     cmdlist = [cmd, 'x']
     if not outdir.endswith('/'):
@@ -25,7 +25,7 @@ def extract_ace (archive, compression, cmd, verbosity, interactive, outdir, pass
     cmdlist.extend([archive, outdir])
     return cmdlist
 
-def list_ace (archive, compression, cmd, verbosity, interactive, password=None):
+def list_ace(archive, compression, cmd, verbosity, interactive, password=None):
     """List an ACE archive."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -37,7 +37,7 @@ def list_ace (archive, compression, cmd, verbosity, interactive, password=None):
     cmdlist.append(archive)
     return cmdlist
 
-def test_ace (archive, compression, cmd, verbosity, interactive, password=None):
+def test_ace(archive, compression, cmd, verbosity, interactive, password=None):
     """Test an ACE archive."""
     cmdlist = [cmd, 't']
     if password:

--- a/patoolib/programs/unadf.py
+++ b/patoolib/programs/unadf.py
@@ -16,12 +16,12 @@
 """Archive commands for the unadf program."""
 
 
-def extract_adf (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_adf(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract an ADF archive."""
     return [cmd, archive, '-d', outdir]
 
 
-def list_adf (archive, compression, cmd, verbosity, interactive):
+def list_adf(archive, compression, cmd, verbosity, interactive):
     """List an ADF archive."""
     return [cmd, '-l', archive]
 

--- a/patoolib/programs/unalz.py
+++ b/patoolib/programs/unalz.py
@@ -20,7 +20,7 @@ def _maybe_add_password(cmdlist, password):
         cmdlist.extend(['-pwd', password])
 
 
-def extract_alzip (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_alzip(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract a ALZIP archive."""
     cmdlist = [cmd, '-d', outdir]
     _maybe_add_password(cmdlist, password)
@@ -28,7 +28,7 @@ def extract_alzip (archive, compression, cmd, verbosity, interactive, outdir, pa
     return cmdlist
 
 
-def list_alzip (archive, compression, cmd, verbosity, interactive, password=None):
+def list_alzip(archive, compression, cmd, verbosity, interactive, password=None):
     """List a ALZIP archive."""
     cmdlist = [cmd, '-l']
     _maybe_add_password(cmdlist, password)

--- a/patoolib/programs/uncompress.py
+++ b/patoolib/programs/uncompress.py
@@ -17,7 +17,7 @@
 from .. import util
 
 
-def extract_compress (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_compress(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a compressed archive."""
     cmdlist = [util.shell_quote(cmd)]
     if verbosity > 1:

--- a/patoolib/programs/unshar.py
+++ b/patoolib/programs/unshar.py
@@ -16,7 +16,7 @@
 """Archive commands for the unshar program."""
 import os
 
-def extract_shar (archive, compression, cmd, verbosity, interactive, outdir):
+def extract_shar(archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a SHAR archive."""
     cmdlist = [cmd, os.path.abspath(archive)]
     return (cmdlist, {'cwd': outdir})

--- a/patoolib/programs/unzip.py
+++ b/patoolib/programs/unzip.py
@@ -19,7 +19,7 @@ def _maybe_add_password(cmdlist, password):
     if password:
         cmdlist.extend(['-P', password])
 
-def extract_zip (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_zip(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract a ZIP archive."""
     cmdlist = [cmd]
     if verbosity > 1:
@@ -28,7 +28,7 @@ def extract_zip (archive, compression, cmd, verbosity, interactive, outdir, pass
     cmdlist.extend(['--', archive, '-d', outdir])
     return cmdlist
 
-def list_zip (archive, compression, cmd, verbosity, interactive, password=None):
+def list_zip(archive, compression, cmd, verbosity, interactive, password=None):
     """List a ZIP archive."""
     cmdlist = [cmd, '-l']
     if verbosity > 1:
@@ -37,7 +37,7 @@ def list_zip (archive, compression, cmd, verbosity, interactive, password=None):
     cmdlist.extend(['--', archive])
     return cmdlist
 
-def test_zip (archive, compression, cmd, verbosity, interactive, password=None):
+def test_zip(archive, compression, cmd, verbosity, interactive, password=None):
     """Test a ZIP archive."""
     cmdlist = [cmd, '-t']
     if verbosity > 1:

--- a/patoolib/programs/xdms.py
+++ b/patoolib/programs/xdms.py
@@ -22,7 +22,7 @@ def _maybe_add_password(cmdlist, password):
         cmdlist.extend(['-p', password])
 
 
-def extract_dms (archive, compression, cmd, verbosity, interactive, outdir, password=None):
+def extract_dms(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract a DMS archive."""
     check_archive_ext(archive)
     cmdlist = [cmd, '-d', outdir]
@@ -33,7 +33,7 @@ def extract_dms (archive, compression, cmd, verbosity, interactive, outdir, pass
     return cmdlist
 
 
-def list_dms (archive, compression, cmd, verbosity, interactive, password=None):
+def list_dms(archive, compression, cmd, verbosity, interactive, password=None):
     """List a DMS archive."""
     check_archive_ext(archive)
     cmdlist = [cmd, 'v']
@@ -42,7 +42,7 @@ def list_dms (archive, compression, cmd, verbosity, interactive, password=None):
     return cmdlist
 
 
-def test_dms (archive, compression, cmd, verbosity, interactive, password=None):
+def test_dms(archive, compression, cmd, verbosity, interactive, password=None):
     """Test a DMS archive."""
     check_archive_ext(archive)
     cmdlist = [cmd, 't']
@@ -51,7 +51,7 @@ def test_dms (archive, compression, cmd, verbosity, interactive, password=None):
     return cmdlist
 
 
-def check_archive_ext (archive):
+def check_archive_ext(archive):
     """xdms(1) cannot handle files with extensions other than '.dms'."""
     if not archive.lower().endswith(".dms"):
         rest = archive[-4:]

--- a/patoolib/programs/xz.py
+++ b/patoolib/programs/xz.py
@@ -21,7 +21,7 @@ from .. import util
 extract_xz = extract_singlefile_standard
 test_xz = test_singlefile_standard
 
-def list_xz (archive, compression, cmd, verbosity, interactive):
+def list_xz(archive, compression, cmd, verbosity, interactive):
     """List a XZ archive."""
     cmdlist = [cmd]
     cmdlist.append('-l')

--- a/patoolib/programs/zip.py
+++ b/patoolib/programs/zip.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the zip program."""
 
-def create_zip (archive, compression, cmd, verbosity, interactive, filenames):
+def create_zip(archive, compression, cmd, verbosity, interactive, filenames):
     """Create a ZIP archive."""
     cmdlist = [cmd, '-r', '-9']
     if verbosity > 1:
@@ -24,7 +24,7 @@ def create_zip (archive, compression, cmd, verbosity, interactive, filenames):
     cmdlist.extend(filenames)
     return cmdlist
 
-def test_zip (archive, compression, cmd, verbosity, interactive):
+def test_zip(archive, compression, cmd, verbosity, interactive):
     """Test a ZIP archive."""
     cmdlist = [cmd, '--test']
     if verbosity > 1:

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -189,13 +189,13 @@ class memoized (object):
         return self.func.__doc__
 
 
-def backtick (cmd, encoding='utf-8'):
+def backtick(cmd, encoding='utf-8'):
     """Return decoded output from command."""
     data = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0]
     return data.decode(encoding)
 
 
-def run (cmd, verbosity=0, **kwargs):
+def run(cmd, verbosity=0, **kwargs):
     """Run command without error checking.
     @return: command return code"""
     # Note that shell_quote_nt() result is not suitable for copy-paste
@@ -219,7 +219,7 @@ def run (cmd, verbosity=0, **kwargs):
     return res
 
 
-def run_checked (cmd, ret_ok=(0,), **kwargs):
+def run_checked(cmd, ret_ok=(0,), **kwargs):
     """Run command and raise PatoolError on error."""
     retcode = run(cmd, **kwargs)
     if retcode not in ret_ok:
@@ -229,7 +229,7 @@ def run_checked (cmd, ret_ok=(0,), **kwargs):
 
 
 @memoized
-def guess_mime (filename):
+def guess_mime(filename):
     """Guess the MIME type of given filename using file(1) and if that
     fails by looking at the filename extension with the Python mimetypes
     module.
@@ -256,7 +256,7 @@ Mime2Encoding = dict([(_val, _key) for _key, _val in Encoding2Mime.items()])
 Mime2Encoding['application/x-gzip'] = 'gzip'
 
 
-def guess_mime_mimedb (filename):
+def guess_mime_mimedb(filename):
     """Guess MIME type from given filename.
     @return: tuple (mime, encoding)
     """
@@ -271,7 +271,7 @@ def guess_mime_mimedb (filename):
     return mime, encoding
 
 
-def guess_mime_file (filename):
+def guess_mime_file(filename):
     """Determine MIME type of filename with file(1):
      (a) using `file --mime`
      (b) using `file` and look the result string
@@ -321,7 +321,7 @@ def guess_mime_file (filename):
         return Encoding2Mime.get(encoding, mime), None
 
 
-def guess_mime_file_mime (file_prog, filename):
+def guess_mime_file_mime(file_prog, filename):
     """Determine MIME type of filename with file(1) and --mime option.
     @return: tuple (mime, encoding)
     """
@@ -337,7 +337,7 @@ def guess_mime_file_mime (file_prog, filename):
     return mime, encoding
 
 
-def get_file_mime_encoding (parts):
+def get_file_mime_encoding(parts):
     """Get encoding value from splitted output of file --mime --uncompress."""
     for part in parts:
         for subpart in part.split(" "):
@@ -381,7 +381,7 @@ FileText2Mime = {
     "ZPAQ stream": "application/zpaq",
 }
 
-def guess_mime_file_text (file_prog, filename):
+def guess_mime_file_text(file_prog, filename):
     """Determine MIME type of filename with file(1)."""
     cmd = [file_prog, "--brief", filename]
     try:
@@ -396,7 +396,7 @@ def guess_mime_file_text (file_prog, filename):
     return None
 
 
-def check_existing_filename (filename, onlyfiles=True):
+def check_existing_filename(filename, onlyfiles=True):
     """Ensure that given filename is a valid, existing file."""
     if not os.path.exists(filename):
         raise PatoolError("file `%s' was not found" % filename)
@@ -412,13 +412,13 @@ def check_writable_filename(filename):
         raise PatoolError("file `%s' is not writable" % filename)
 
 
-def check_new_filename (filename):
+def check_new_filename(filename):
     """Check that filename does not already exist."""
     if os.path.exists(filename):
         raise PatoolError("cannot overwrite existing file `%s'" % filename)
 
 
-def check_archive_filelist (filenames):
+def check_archive_filelist(filenames):
     """Check that file list is not empty and contains only existing files."""
     if not filenames:
         raise PatoolError("cannot create archive with empty filelist")
@@ -426,7 +426,7 @@ def check_archive_filelist (filenames):
         check_existing_filename(filename, onlyfiles=False)
 
 
-def set_mode (filename, flags):
+def set_mode(filename, flags):
     """Set mode flags for given filename if not already set."""
     try:
         mode = os.lstat(filename).st_mode
@@ -465,17 +465,17 @@ def strsize(b, grouping=True):
     return u"%sGB" % locale.format("%.1f", (float(b) / (1024*1024*1024)), grouping)
 
 
-def tmpdir (dir=None):
+def tmpdir(dir=None):
     """Return a temporary directory for extraction."""
     return tempfile.mkdtemp(suffix='', prefix='Unpack_', dir=dir)
 
 
-def tmpfile (dir=None, prefix="temp", suffix=None):
+def tmpfile(dir=None, prefix="temp", suffix=None):
     """Return a temporary file."""
     return tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)[1]
 
 
-def shell_quote (value):
+def shell_quote(value):
     """Quote all shell metacharacters in given string value with strong
     (ie. single) quotes, handling the single quote especially."""
     if os.name == 'nt':
@@ -483,7 +483,7 @@ def shell_quote (value):
     return "'%s'" % value.replace("'", r"'\''")
 
 
-def shell_quote_nt (value):
+def shell_quote_nt(value):
     """Quote argument for Windows system. Modeled after distutils
     _nt_quote_args() function."""
     if " " in value:
@@ -491,7 +491,7 @@ def shell_quote_nt (value):
     return value
 
 
-def stripext (filename):
+def stripext(filename):
     """Return the basename without extension of given filename."""
     basename, _ = os.path.splitext(os.path.basename(filename))
     if basename.endswith(".tar"):
@@ -499,7 +499,7 @@ def stripext (filename):
     return basename
 
 
-def get_single_outfile (directory, archive, extension=""):
+def get_single_outfile(directory, archive, extension=""):
     """Get output filename if archive is in a single file format like gzip."""
     outfile = os.path.join(directory, stripext(archive))
     if os.path.exists(outfile + extension):
@@ -513,12 +513,12 @@ def get_single_outfile (directory, archive, extension=""):
     return outfile + extension
 
 
-def log_error (msg, out=sys.stderr):
+def log_error(msg, out=sys.stderr):
     """Print error message to stderr (or any other given output)."""
     print("patool error:", msg, file=out)
 
 
-def log_info (msg, out=sys.stdout):
+def log_info(msg, out=sys.stdout):
     """Print info message to stdout (or any other given output)."""
     print("patool:", msg, file=out)
 
@@ -604,7 +604,7 @@ def p7zip_supports_rar():
 
 
 @memoized
-def find_program (program):
+def find_program(program):
     """Look for program in environment PATH variable."""
     if os.name == 'nt':
         # Add some well-known archiver programs to the search path
@@ -618,7 +618,7 @@ def find_program (program):
     return which(program, path=path)
 
 
-def append_to_path (path, directory):
+def append_to_path(path, directory):
     """Add a directory to the PATH environment variable, if it is a valid
     directory."""
     if not os.path.isdir(directory) or directory in path:
@@ -628,7 +628,7 @@ def append_to_path (path, directory):
     return path + directory
 
 
-def get_nt_7z_dir ():
+def get_nt_7z_dir():
     """Return 7-Zip directory from registry, or an empty string."""
     # Python 3.x renamed the _winreg module to winreg
     try:
@@ -645,13 +645,13 @@ def get_nt_7z_dir ():
         return ""
 
 
-def get_nt_program_dir ():
+def get_nt_program_dir():
     """Return the Windows program files directory."""
     progvar = "%ProgramFiles%"
     return os.path.expandvars(progvar)
 
 
-def get_nt_mac_dir ():
+def get_nt_mac_dir():
     """Return Monkey Audio Compressor (MAC) directory."""
     return os.path.join(get_nt_program_dir(), "Monkey's Audio")
 
@@ -661,14 +661,14 @@ def get_nt_winrar_dir():
     return os.path.join(get_nt_program_dir(), "WinRAR")
 
 
-def strlist_with_or (alist):
+def strlist_with_or(alist):
     """Return comma separated string, and last entry appended with ' or '."""
     if len(alist) > 1:
         return "%s or %s" % (", ".join(alist[:-1]), alist[-1])
     return ", ".join(alist)
 
 
-def is_same_file (filename1, filename2):
+def is_same_file(filename1, filename2):
     """Check if filename1 and filename2 point to the same file object.
     There can be false negatives, ie. the result is False, but it is
     the same file anyway. Reason is that network filesystems can create
@@ -681,7 +681,7 @@ def is_same_file (filename1, filename2):
     return is_same_filename(filename1, filename2)
 
 
-def is_same_filename (filename1, filename2):
+def is_same_filename(filename1, filename2):
     """Check if filename1 and filename2 are the same filename."""
     return os.path.realpath(filename1) == os.path.realpath(filename2)
 

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,12 @@ MyName = "Bastian Kleineidam"
 MyEmail = "bastian.kleineidam@web.de"
 
 
-def normpath (path):
+def normpath(path):
     """Norm a path name to platform specific notation."""
     return os.path.normpath(path)
 
 
-def cnormpath (path):
+def cnormpath(path):
     """Norm a path name to platform specific notation and make it absolute."""
     path = normpath(path)
     if os.name == 'nt':
@@ -52,7 +52,7 @@ def cnormpath (path):
 
 
 release_ro = re.compile(r"\(released (.+)\)")
-def get_release_date ():
+def get_release_date():
     """Parse and return relase date as string from doc/changelog.txt."""
     fname = os.path.join("doc", "changelog.txt")
     release_date = "unknown"
@@ -75,7 +75,7 @@ else:
 class MyInstallLib (install_lib, object):
     """Custom library installation."""
 
-    def install (self):
+    def install(self):
         """Install the generated config file."""
         outs = super(MyInstallLib, self).install()
         infile = self.create_conf_file()
@@ -84,7 +84,7 @@ class MyInstallLib (install_lib, object):
         outs.append(outfile)
         return outs
 
-    def create_conf_file (self):
+    def create_conf_file(self):
         """Create configuration file."""
         cmd_obj = self.distribution.get_command_obj("install")
         cmd_obj.ensure_finalized()
@@ -118,11 +118,11 @@ class MyInstallLib (install_lib, object):
         self.distribution.create_conf_file(data, directory=self.install_lib)
         return self.get_conf_output()
 
-    def get_conf_output (self):
+    def get_conf_output(self):
         """Get filename for distribution configuration file."""
         return self.distribution.get_conf_filename(self.install_lib)
 
-    def get_outputs (self):
+    def get_outputs(self):
         """Add the generated config file to the list of outputs."""
         outs = super(MyInstallLib, self).get_outputs()
         conf_output = self.get_conf_output()
@@ -135,12 +135,12 @@ class MyInstallLib (install_lib, object):
 class MyDistribution (Distribution, object):
     """Custom distribution class generating config file."""
 
-    def __init__ (self, attrs):
+    def __init__(self, attrs):
         """Set console and windows scripts."""
         super(MyDistribution, self).__init__(attrs)
         self.console = ['patool']
 
-    def run_commands (self):
+    def run_commands(self):
         """Generate config file and run commands."""
         cwd = os.getcwd()
         data = []
@@ -150,11 +150,11 @@ class MyDistribution (Distribution, object):
         self.create_conf_file(data)
         super(MyDistribution, self).run_commands()
 
-    def get_conf_filename (self, directory):
+    def get_conf_filename(self, directory):
         """Get name for config file."""
         return os.path.join(directory, "_%s_configdata.py" % self.get_name())
 
-    def create_conf_file (self, data, directory=None):
+    def create_conf_file(self, data, directory=None):
         """Create local config file from given data (list of lines) in
         the directory (or current directory if not given)."""
         data.insert(0, "# this file is automatically created by setup.py")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -67,10 +67,10 @@ def needs_module(name):
     return _need_func(has_module, name, 'Python module')
 
 
-def needs_codec (program, codec):
+def needs_codec(program, codec):
     """Decorator skipping test if given program codec is not available."""
-    def check_prog (f):
-        def newfunc (*args, **kwargs):
+    def check_prog(f):
+        def newfunc(*args, **kwargs):
             if not patoolib.util.find_program(program):
                 pytest.skip("program `%s' not available" % program)
             if not has_codec(program, codec):
@@ -81,7 +81,7 @@ def needs_codec (program, codec):
     return check_prog
 
 
-def has_codec (program, codec):
+def has_codec(program, codec):
     """Test if program supports given codec."""
     if program == '7z' and codec == 'rar':
         return patoolib.util.p7zip_supports_rar()

--- a/tests/archives/__init__.py
+++ b/tests/archives/__init__.py
@@ -54,7 +54,7 @@ class ArchiveTest (unittest.TestCase):
     # default archive basename to check
     filename = 't'
 
-    def archive_commands (self, filename, **kwargs):
+    def archive_commands(self, filename, **kwargs):
         """Run archive commands list, test, extract and create.
         All keyword arguments are delegated to the create test function."""
         self.archive_list(filename)
@@ -64,7 +64,7 @@ class ArchiveTest (unittest.TestCase):
         if not kwargs.get('skip_create'):
             self.archive_create(filename, **kwargs)
 
-    def archive_extract (self, filename, check=Content.Recursive):
+    def archive_extract(self, filename, check=Content.Recursive):
         """Test archive extraction."""
         archive = os.path.join(datadir, filename)
         self.assertTrue(os.path.isabs(archive), "archive path is not absolute: %r" % archive)
@@ -73,7 +73,7 @@ class ArchiveTest (unittest.TestCase):
         relarchive = os.path.join("..", archive[len(basedir)+1:])
         self._archive_extract(relarchive, check, verbosity=1)
 
-    def _archive_extract (self, archive, check, verbosity=0):
+    def _archive_extract(self, archive, check, verbosity=0):
         # create a temporary directory for extraction
         tmpdir = patoolib.util.tmpdir(dir=basedir)
         try:
@@ -88,7 +88,7 @@ class ArchiveTest (unittest.TestCase):
         finally:
             shutil.rmtree(tmpdir)
 
-    def check_extracted_archive (self, archive, output, check):
+    def check_extracted_archive(self, archive, output, check):
         if check == Content.Recursive:
             # outdir is the 't' directory of the archive
             self.assertEqual(output, 't')
@@ -106,30 +106,30 @@ class ArchiveTest (unittest.TestCase):
             txtfile2 = os.path.join(output, 't2.txt')
             self.check_textfile(txtfile2, 't2.txt')
 
-    def check_directory (self, dirname, expectedname):
+    def check_directory(self, dirname, expectedname):
         """Check that directory exists."""
         self.assertTrue(os.path.isdir(dirname), dirname)
         self.assertEqual(os.path.basename(dirname), expectedname)
 
-    def check_textfile (self, filename, expectedname):
+    def check_textfile(self, filename, expectedname):
         """Check that filename exists and has the default content."""
         self.assertTrue(os.path.isfile(filename), repr(filename))
         self.assertEqual(os.path.basename(filename), expectedname)
         self.assertEqual(get_filecontent(filename), TextFileContent)
 
-    def archive_list (self, filename):
+    def archive_list(self, filename):
         """Test archive listing."""
         archive = os.path.join(datadir, filename)
         for verbosity in (-1, 0, 1, 2):
             patoolib.list_archive(archive, program=self.program, verbosity=verbosity, interactive=False, password=self.password)
 
-    def archive_test (self, filename):
+    def archive_test(self, filename):
         """Test archive testing."""
         archive = os.path.join(datadir, filename)
         for verbosity in (-1, 0, 1, 2):
             patoolib.test_archive(archive, program=self.program, verbosity=verbosity, interactive=False, password=self.password)
 
-    def archive_create (self, archive, srcfiles=None, check=Content.Recursive):
+    def archive_create(self, archive, srcfiles=None, check=Content.Recursive):
         """Test archive creation."""
         if srcfiles is None:
             if check == Content.Recursive:
@@ -150,7 +150,7 @@ class ArchiveTest (unittest.TestCase):
             if olddir:
                 os.chdir(olddir)
 
-    def _archive_create (self, archive, srcfiles, program=None, verbosity=0):
+    def _archive_create(self, archive, srcfiles, program=None, verbosity=0):
         """Create archive from filename."""
         for srcfile in srcfiles:
             self.assertFalse(os.path.isabs(srcfile))

--- a/tests/archives/test_7z.py
+++ b/tests/archives/test_7z.py
@@ -21,7 +21,7 @@ class Test7z (ArchiveTest):
     program = '7z'
 
     @needs_program(program)
-    def test_7z (self):
+    def test_7z(self):
         self.archive_commands('t .7z')
         self.archive_commands('t .cb7')
         self.archive_commands('t.zip')
@@ -67,7 +67,7 @@ class Test7z (ArchiveTest):
         self.archive_create('t.txt.bz2', check=Content.Singlefile)
 
     @needs_codec(program, 'rar')
-    def test_7z_rar (self):
+    def test_7z_rar(self):
         # only succeeds with the rar module for 7z installed
         self.archive_list('t.rar')
         self.archive_extract('t.rar')
@@ -75,7 +75,7 @@ class Test7z (ArchiveTest):
 
     @needs_program('file')
     @needs_program(program)
-    def test_7z_file (self):
+    def test_7z_file(self):
         self.archive_commands('t.7z.foo', skip_create=True)
         self.archive_commands('t.cb7.foo', skip_create=True)
         self.archive_commands('t.zip.foo', skip_create=True)
@@ -114,7 +114,7 @@ class Test7z (ArchiveTest):
 
     @needs_program('file')
     @needs_codec(program, 'rar')
-    def test_7z_rar_file (self):
+    def test_7z_rar_file(self):
         # only succeeds with the rar module for 7z installed
         self.archive_list(self.filename + '.rar.foo')
         self.archive_extract(self.filename + '.rar.foo')
@@ -127,7 +127,7 @@ class Test7zPassword(ArchiveTest):
     password = 'thereisnotry'
 
     @needs_program(program)
-    def test_7z (self):
+    def test_7z(self):
         self.archive_commands('p .7z')
         self.archive_commands('p.zip')
         self.archive_commands('p.cbz')
@@ -136,7 +136,7 @@ class Test7zPassword(ArchiveTest):
         self.archive_test('p.arj')
 
     @needs_codec(program, 'rar')
-    def test_7z_rar (self):
+    def test_7z_rar(self):
         # only succeeds with the rar module for 7z installed
         self.archive_list('p.rar')
         self.archive_extract('p.rar')
@@ -144,7 +144,7 @@ class Test7zPassword(ArchiveTest):
 
     @needs_program('file')
     @needs_program(program)
-    def test_7z_file (self):
+    def test_7z_file(self):
         self.archive_commands('p.7z.foo', skip_create=True)
         self.archive_commands('p.zip.foo', skip_create=True)
         self.archive_commands('p.cbz.foo', skip_create=True)
@@ -154,7 +154,7 @@ class Test7zPassword(ArchiveTest):
 
     @needs_program('file')
     @needs_codec(program, 'rar')
-    def test_7z_rar_file (self):
+    def test_7z_rar_file(self):
         # only succeeds with the rar module for 7z installed
         self.archive_list('p.rar.foo')
         self.archive_extract('p.rar.foo')

--- a/tests/archives/test_7za.py
+++ b/tests/archives/test_7za.py
@@ -21,7 +21,7 @@ class Test7za (ArchiveTest):
     program = '7za'
 
     @needs_program(program)
-    def test_p7azip (self):
+    def test_p7azip(self):
         self.archive_commands('t .7z')
         self.archive_commands('t .cb7')
         self.archive_commands('t.zip')
@@ -47,7 +47,7 @@ class Test7za (ArchiveTest):
 
     @needs_program('file')
     @needs_program(program)
-    def test_7za_file (self):
+    def test_7za_file(self):
         self.archive_commands('t.7z.foo', skip_create=True)
         self.archive_commands('t.cb7.foo', skip_create=True)
         self.archive_commands('t.zip.foo', skip_create=True)

--- a/tests/archives/test_7zr.py
+++ b/tests/archives/test_7zr.py
@@ -21,12 +21,12 @@ class Test7zr (ArchiveTest):
     program = '7zr'
 
     @needs_program(program)
-    def test_7zr (self):
+    def test_7zr(self):
         self.archive_commands('t .7z')
         self.archive_commands('t .cb7')
 
     @needs_program('file')
     @needs_program(program)
-    def test_7z_file (self):
+    def test_7z_file(self):
         self.archive_commands('t.7z.foo', skip_create=True)
         self.archive_commands('t.cb7.foo', skip_create=True)

--- a/tests/archives/test_archmage.py
+++ b/tests/archives/test_archmage.py
@@ -21,12 +21,12 @@ class TestArchmage (ArchiveTest):
     program = 'archmage'
 
     @needs_program(program)
-    def test_archmage (self):
+    def test_archmage(self):
         self.archive_extract('t.chm', check=None)
         self.archive_test('t.chm')
 
     @needs_program('file')
     @needs_program(program)
-    def test_archmage_file (self):
+    def test_archmage_file(self):
         self.archive_extract('t.chm.foo', check=None)
         self.archive_test('t.chm.foo')

--- a/tests/archives/test_bsdtar.py
+++ b/tests/archives/test_bsdtar.py
@@ -21,79 +21,79 @@ class TestBsdtar (ArchiveTest):
     program = 'bsdtar'
 
     @needs_program(program)
-    def test_bsdtar (self):
+    def test_bsdtar(self):
         self.archive_commands('t.tar')
         self.archive_commands('t.cbt')
 
     @needs_codec(program, 'gzip')
-    def test_bsdtar_gz (self):
+    def test_bsdtar_gz(self):
         self.archive_commands('t.tar.gz')
         self.archive_commands('t.tgz')
 
     @needs_program(program)
     @needs_program('compress')
-    def test_bsdtar_z (self):
+    def test_bsdtar_z(self):
         self.archive_commands('t.tar.Z')
         self.archive_commands('t.taz')
 
     @needs_codec(program, 'bzip2')
-    def test_bsdtar_bz2 (self):
+    def test_bsdtar_bz2(self):
         self.archive_commands('t.tar.bz2')
         self.archive_commands('t.tbz2')
 
     @needs_codec(program, 'lzma')
-    def test_bsdtar_lzma (self):
+    def test_bsdtar_lzma(self):
         self.archive_commands('t.tar.lzma')
 
     # bsdtar cannot read archives created with tar and lzip
     #@needs_program(program)
     #@needs_program('lzip')
-    #def test_bsdtar_lzip (self):
+    #def test_bsdtar_lzip(self):
     #    self.archive_commands('t.tar.lz')
 
     @needs_codec(program, 'xz')
-    def test_bsdtar_xz (self):
+    def test_bsdtar_xz(self):
         self.archive_commands('t.tar.xz')
 
     @needs_program('file')
     @needs_program(program)
-    def test_bsdtar_file (self):
+    def test_bsdtar_file(self):
         self.archive_commands('t.tar.foo', skip_create=True)
         self.archive_commands('t.cbt.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'gzip')
-    def test_bsdtar_gz_file (self):
+    def test_bsdtar_gz_file(self):
         self.archive_commands('t.tar.gz.foo', skip_create=True)
         self.archive_commands('t.tgz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'compress')
-    def test_bsdtar_z_file (self):
+    def test_bsdtar_z_file(self):
         self.archive_commands('t.tar.Z.foo', skip_create=True)
         self.archive_commands('t.taz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'bzip2')
-    def test_bsdtar_bz2_file (self):
+    def test_bsdtar_bz2_file(self):
         self.archive_commands('t.tar.bz2.foo', skip_create=True)
         self.archive_commands('t.tbz2.foo', skip_create=True)
 
     # file(1) does not recognize .lzma files (at least not with --uncompress)
     #@needs_program('file')
     #@needs_codec(program, 'lzma')
-    #def test_bsdtar_lzma_file (self):
+    #def test_bsdtar_lzma_file(self):
     #    self.archive_commands('t.tar.lzma.foo', skip_create=True)
 
     # bsdtar cannot read archives created with tar and lzip
     #@needs_program('lzip')
     #@needs_program('file')
     #@needs_codec(program, 'lzip')
-    #def test_bsdtar_lzip_file (self):
+    #def test_bsdtar_lzip_file(self):
     #    self.archive_commands('t.tar.lz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'xz')
-    def test_bsdtar_xz_file (self):
+    def test_bsdtar_xz_file(self):
         self.archive_commands('t.tar.xz.foo', skip_create=True)
 

--- a/tests/archives/test_bzip2.py
+++ b/tests/archives/test_bzip2.py
@@ -21,14 +21,14 @@ class TestBzip2 (ArchiveTest):
     program = 'bzip2'
 
     @needs_program(program)
-    def test_bzip2 (self):
+    def test_bzip2(self):
         self.archive_extract('t.txt.bz2', check=Content.Singlefile)
         self.archive_test('t.txt.bz2')
         self.archive_create('t.txt.bz2', check=Content.Singlefile)
 
     @needs_program('file')
     @needs_program(program)
-    def test_bzip2_file (self):
+    def test_bzip2_file(self):
         self.archive_extract('t.txt.bz2.foo', check=Content.Singlefile)
         self.archive_test('t.txt.bz2.foo')
 

--- a/tests/archives/test_cabextract.py
+++ b/tests/archives/test_cabextract.py
@@ -21,7 +21,7 @@ class TestCabextract (ArchiveTest):
     program = 'cabextract'
 
     @needs_program(program)
-    def test_cabextract (self):
+    def test_cabextract(self):
         self.archive_list('t.cab')
         self.archive_extract('t.cab', check=None)
 

--- a/tests/archives/test_chmlib.py
+++ b/tests/archives/test_chmlib.py
@@ -21,10 +21,10 @@ class TestChmlib (ArchiveTest):
     program = 'extract_chmLib'
 
     @needs_program(program)
-    def test_archmage (self):
+    def test_archmage(self):
         self.archive_extract('t.chm', check=None)
 
     @needs_program('file')
     @needs_program(program)
-    def test_archmage_file (self):
+    def test_archmage_file(self):
         self.archive_extract('t.chm.foo', check=None)

--- a/tests/archives/test_compress.py
+++ b/tests/archives/test_compress.py
@@ -21,5 +21,5 @@ class TestCompress (ArchiveTest):
     program = 'compress'
 
     @needs_program(program)
-    def test_compress (self):
+    def test_compress(self):
         self.archive_create('t.txt.Z', check=Content.Singlefile)

--- a/tests/archives/test_gzip.py
+++ b/tests/archives/test_gzip.py
@@ -21,7 +21,7 @@ class TestGzip (ArchiveTest):
     program = 'gzip'
 
     @needs_program(program)
-    def test_gzip (self):
+    def test_gzip(self):
         self.archive_commands('t.txt.gz', check=Content.Singlefile)
         self.archive_extract('t.txt.Z', check=Content.Singlefile)
 

--- a/tests/archives/test_lbzip2.py
+++ b/tests/archives/test_lbzip2.py
@@ -21,14 +21,14 @@ class TestLbzip2 (ArchiveTest):
     program = 'lbzip2'
 
     @needs_program(program)
-    def test_lbzip2 (self):
+    def test_lbzip2(self):
         self.archive_extract('t.txt.bz2', check=Content.Singlefile)
         self.archive_test('t.txt.bz2')
         self.archive_create('t.txt.bz2', check=Content.Singlefile)
 
     @needs_program('file')
     @needs_program(program)
-    def test_lbzip2_file (self):
+    def test_lbzip2_file(self):
         self.archive_extract('t.txt.bz2.foo', check=Content.Singlefile)
         self.archive_test('t.txt.bz2.foo')
 

--- a/tests/archives/test_lcab.py
+++ b/tests/archives/test_lcab.py
@@ -22,6 +22,6 @@ class TestLcab (ArchiveTest):
 
     @needs_program(program)
     @needs_program('cabextract')
-    def test_lcab (self):
+    def test_lcab(self):
         self.archive_create('t.cab')
 

--- a/tests/archives/test_pbzip2.py
+++ b/tests/archives/test_pbzip2.py
@@ -21,14 +21,14 @@ class TestPbzip2 (ArchiveTest):
     program = 'pbzip2'
 
     @needs_program(program)
-    def test_pbzip2 (self):
+    def test_pbzip2(self):
         self.archive_extract('t.txt.bz2', check=Content.Singlefile)
         self.archive_test('t.txt.bz2')
         self.archive_create('t.txt.bz2', check=Content.Singlefile)
 
     @needs_program('file')
     @needs_program(program)
-    def test_pbzip2_file (self):
+    def test_pbzip2_file(self):
         self.archive_extract('t.txt.bz2.foo', check=Content.Singlefile)
         self.archive_test('t.txt.bz2.foo')
 

--- a/tests/archives/test_pigz.py
+++ b/tests/archives/test_pigz.py
@@ -21,11 +21,11 @@ class TestPigz (ArchiveTest):
     program = 'pigz'
 
     @needs_program(program)
-    def test_pigz (self):
+    def test_pigz(self):
         self.archive_commands('t.txt.gz', check=Content.Singlefile)
 
     @needs_program('file')
     @needs_program(program)
-    def test_pigz_file (self):
+    def test_pigz_file(self):
         self.archive_commands('t.txt.gz.foo', check=Content.Singlefile,
           skip_create=True, skip_test=True)

--- a/tests/archives/test_pybz2.py
+++ b/tests/archives/test_pybz2.py
@@ -21,12 +21,12 @@ class TestPybz2 (ArchiveTest):
     program = 'py_bz2'
 
     @needs_program('bzip2')
-    def test_py_bz2 (self):
+    def test_py_bz2(self):
         self.archive_extract('t.txt.bz2', check=Content.Singlefile)
         # bzip2 is used to test the created archive
         self.archive_create('t.txt.bz2', check=Content.Singlefile)
 
     @needs_program('file')
-    def test_py_bz2_file (self):
+    def test_py_bz2_file(self):
         self.archive_extract('t.txt.bz2.foo', check=Content.Singlefile)
 

--- a/tests/archives/test_pyecho.py
+++ b/tests/archives/test_pyecho.py
@@ -20,7 +20,7 @@ class TestPyecho (ArchiveTest):
 
     program = 'py_echo'
 
-    def test_py_echo (self):
+    def test_py_echo(self):
         self.archive_list('t.txt.bz2')
         self.archive_list('t.txt.Z')
         self.archive_list('t.txt.lzma')
@@ -32,7 +32,7 @@ class TestPyecho (ArchiveTest):
         self.archive_list('t.flac')
 
     @needs_program('file')
-    def test_py_echo_file (self):
+    def test_py_echo_file(self):
         self.archive_list('t.txt.bz2.foo')
         self.archive_list('t.txt.Z.foo')
         # file(1) does not recognize .lzma files

--- a/tests/archives/test_pygzip.py
+++ b/tests/archives/test_pygzip.py
@@ -21,12 +21,12 @@ class TestPygzip (ArchiveTest):
     program = 'py_gzip'
 
     @needs_program('gzip')
-    def test_py_gzip (self):
+    def test_py_gzip(self):
         self.archive_extract('t.txt.gz', check=Content.Singlefile)
         # gzip is used to test the created archive
         self.archive_create('t.txt.gz', check=Content.Singlefile)
 
     @needs_program('file')
-    def test_py_gzip_file (self):
+    def test_py_gzip_file(self):
         self.archive_extract('t.txt.gz.foo', check=Content.Singlefile)
 

--- a/tests/archives/test_pylzma.py
+++ b/tests/archives/test_pylzma.py
@@ -22,7 +22,7 @@ class TestPylzma (ArchiveTest):
 
     @needs_program('xz')
     @needs_module('lzma')
-    def test_py_lzma (self):
+    def test_py_lzma(self):
         self.archive_extract('t.txt.lzma', check=Content.Singlefile)
         self.archive_extract('t.txt.xz', check=Content.Singlefile)
         # xz is used to test the created archive
@@ -31,7 +31,7 @@ class TestPylzma (ArchiveTest):
 
     @needs_program('file')
     @needs_module('lzma')
-    def test_py_lzma_file (self):
+    def test_py_lzma_file(self):
         self.archive_extract('t.txt.lzma.foo', check=Content.Singlefile)
         self.archive_extract('t.txt.xz.foo', check=Content.Singlefile)
 

--- a/tests/archives/test_pytarfile.py
+++ b/tests/archives/test_pytarfile.py
@@ -20,29 +20,29 @@ class TestPytarfile (ArchiveTest):
 
     program = 'py_tarfile'
 
-    def test_py_tarfile (self):
+    def test_py_tarfile(self):
         self.archive_commands('t.tar')
         self.archive_commands('t.cbt')
 
-    def test_py_tarfile_gz (self):
+    def test_py_tarfile_gz(self):
         self.archive_commands('t.tar.gz')
         self.archive_commands('t.tgz')
 
-    def test_py_tarfile_bz2 (self):
+    def test_py_tarfile_bz2(self):
         self.archive_commands('t.tar.bz2')
         self.archive_commands('t.tbz2')
 
     @needs_program('file')
-    def test_py_tarfile_file (self):
+    def test_py_tarfile_file(self):
         self.archive_commands('t.tar.foo', skip_create=True)
         self.archive_commands('t.cbt.foo', skip_create=True)
 
     @needs_program('file')
-    def test_py_tarfile_gz_file (self):
+    def test_py_tarfile_gz_file(self):
         self.archive_commands('t.tar.gz.foo', skip_create=True)
         self.archive_commands('t.tgz.foo', skip_create=True)
 
     @needs_program('file')
-    def test_py_tarfile_bz2_file (self):
+    def test_py_tarfile_bz2_file(self):
         self.archive_commands('t.tar.bz2.foo', skip_create=True)
         self.archive_commands('t.tbz2.foo', skip_create=True)

--- a/tests/archives/test_star.py
+++ b/tests/archives/test_star.py
@@ -21,75 +21,75 @@ class TestStar (ArchiveTest):
     program = 'star'
 
     @needs_program(program)
-    def test_star (self):
+    def test_star(self):
         self.archive_commands('t.tar')
         self.archive_commands('t.cbt')
 
     @needs_codec(program, 'gzip')
-    def test_star_gz (self):
+    def test_star_gz(self):
         self.archive_commands('t.tar.gz')
         self.archive_commands('t.tgz')
 
     @needs_program(program)
     @needs_program('compress')
-    def test_star_z (self):
+    def test_star_z(self):
         self.archive_commands('t.tar.Z')
         self.archive_commands('t.taz')
 
     @needs_codec(program, 'bzip2')
-    def test_star_bz2 (self):
+    def test_star_bz2(self):
         self.archive_commands('t.tar.bz2')
         self.archive_commands('t.tbz2')
 
     @needs_codec(program, 'lzma')
-    def test_star_lzma (self):
+    def test_star_lzma(self):
         self.archive_commands('t.tar.lzma')
 
     @needs_program(program)
     @needs_program('lzip')
-    def test_star_lzip (self):
+    def test_star_lzip(self):
         self.archive_commands('t.tar.lz')
 
     @needs_codec(program, 'xz')
-    def test_star_xz (self):
+    def test_star_xz(self):
         self.archive_commands('t.tar.xz')
 
     @needs_program('file')
     @needs_program(program)
-    def test_star_file (self):
+    def test_star_file(self):
         self.archive_commands('t.tar.foo', skip_create=True)
         self.archive_commands('t.cbt.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'gzip')
-    def test_star_gz_file (self):
+    def test_star_gz_file(self):
         self.archive_commands('t.tar.gz.foo', skip_create=True)
         self.archive_commands('t.tgz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'compress')
-    def test_star_z_file (self):
+    def test_star_z_file(self):
         self.archive_commands('t.tar.Z.foo', skip_create=True)
         self.archive_commands('t.taz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'bzip2')
-    def test_star_bz2_file (self):
+    def test_star_bz2_file(self):
         self.archive_commands('t.tar.bz2.foo', skip_create=True)
         self.archive_commands('t.tbz2.foo', skip_create=True)
 
     # file(1) does not recognize .lzma files
     #@needs_program('file')
     #@needs_codec(program, 'lzma')
-    #def test_star_lzma_file (self):
+    #def test_star_lzma_file(self):
     #    self.archive_commands('t.tar.lzma.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'lzip')
-    def test_star_lzip_file (self):
+    def test_star_lzip_file(self):
         self.archive_commands('t.tar.lz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'xz')
-    def test_star_xz_file (self):
+    def test_star_xz_file(self):
         self.archive_commands('t.tar.xz.foo', skip_create=True)

--- a/tests/archives/test_tar.py
+++ b/tests/archives/test_tar.py
@@ -21,70 +21,70 @@ class TestTar (ArchiveTest):
     program = 'tar'
 
     @needs_program(program)
-    def test_tar (self):
+    def test_tar(self):
         self.archive_commands('t.tar')
         self.archive_commands('t.cbt')
 
     @needs_codec(program, 'gzip')
-    def test_tar_gz (self):
+    def test_tar_gz(self):
         self.archive_commands('t.tar.gz')
         self.archive_commands('t.tgz')
 
     @needs_program(program)
     @needs_program('compress')
-    def test_tar_z (self):
+    def test_tar_z(self):
         self.archive_commands('t.tar.Z')
         self.archive_commands('t.taz')
 
     @needs_codec(program, 'bzip2')
-    def test_tar_bz2 (self):
+    def test_tar_bz2(self):
         self.archive_commands('t.tar.bz2')
         self.archive_commands('t.tbz2')
 
     @needs_codec(program, 'lzma')
-    def test_tar_lzma (self):
+    def test_tar_lzma(self):
         self.archive_commands('t.tar.lzma')
 
     # even though clzip would support extracting .lz files, the
     # file(1) --uncompress command does not use it for achive detection
     @needs_program(program)
     @needs_program('lzip')
-    def test_tar_lzip (self):
+    def test_tar_lzip(self):
         self.archive_commands('t.tar.lz')
 
     @needs_codec(program, 'xz')
-    def test_tar_xz (self):
+    def test_tar_xz(self):
         self.archive_commands('t.tar.xz')
 
     @needs_program('file')
     @needs_program(program)
-    def test_tar_file (self):
+    def test_tar_file(self):
         self.archive_commands('t.tar.foo', skip_create=True)
         self.archive_commands('t.cbt.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'gzip')
-    def test_tar_gz_file (self):
+    def test_tar_gz_file(self):
         self.archive_commands('t.tar.gz.foo', skip_create=True)
         self.archive_commands('t.tgz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_program('compress')
     @needs_codec(program, 'compress')
-    def test_tar_z_file (self):
+    def test_tar_z_file(self):
         self.archive_commands('t.tar.Z.foo', skip_create=True)
         self.archive_commands('t.taz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'bzip2')
-    def test_tar_bz2_file (self):
+    def test_tar_bz2_file(self):
         self.archive_commands('t.tar.bz2.foo', skip_create=True)
         self.archive_commands('t.tbz2.foo', skip_create=True)
 
     # file(1) does not recognize .lzma files (at least not with --uncompress)
     #@needs_program('file')
     #@needs_codec(program, 'lzma')
-    #def test_tar_lzma_file (self):
+    #def test_tar_lzma_file(self):
     #    self.archive_commands('t.tar.lzma.foo', format="tar", compression="lzma")
 
     # even though clzip would support extracting .lz files, the
@@ -92,10 +92,10 @@ class TestTar (ArchiveTest):
     @needs_program('lzip')
     @needs_program('file')
     @needs_codec(program, 'lzip')
-    def test_tar_lzip_file (self):
+    def test_tar_lzip_file(self):
         self.archive_commands('t.tar.lz.foo', skip_create=True)
 
     @needs_program('file')
     @needs_codec(program, 'xz')
-    def test_tar_xz_file (self):
+    def test_tar_xz_file(self):
         self.archive_commands('t.tar.xz.foo', skip_create=True)

--- a/tests/archives/test_uncompressreal.py
+++ b/tests/archives/test_uncompressreal.py
@@ -21,11 +21,11 @@ class TestUncompressReal (ArchiveTest):
     program = 'uncompress.real'
 
     @needs_program(program)
-    def test_uncompress (self):
+    def test_uncompress(self):
         self.archive_extract('t.txt.Z', check=Content.Singlefile)
 
     @needs_program('file')
     @needs_program(program)
-    def test_uncompress_file (self):
+    def test_uncompress_file(self):
         self.archive_extract('t.txt.Z.foo', check=Content.Singlefile)
 

--- a/tests/archives/test_unzip.py
+++ b/tests/archives/test_unzip.py
@@ -21,7 +21,7 @@ class TestUnzip (ArchiveTest):
     program = 'unzip'
 
     @needs_program(program)
-    def test_unzip (self):
+    def test_unzip(self):
         self.archive_extract('t.zip', check=None)
         self.archive_list('t.zip')
         self.archive_test('t.zip')
@@ -40,7 +40,7 @@ class TestUnzip (ArchiveTest):
 
     @needs_program('file')
     @needs_program(program)
-    def test_unzip_file (self):
+    def test_unzip_file(self):
         self.archive_extract('t.zip.foo', check=None)
         self.archive_list('t.zip.foo')
         self.archive_test('t.zip.foo')
@@ -64,7 +64,7 @@ class TestUnzipPassword (ArchiveTest):
     password = 'thereisnotry'
 
     @needs_program(program)
-    def test_unzip (self):
+    def test_unzip(self):
         self.archive_extract('p.zip', check=None)
         self.archive_list('p.zip')
         self.archive_test('p.zip')
@@ -74,7 +74,7 @@ class TestUnzipPassword (ArchiveTest):
 
     @needs_program('file')
     @needs_program(program)
-    def test_unzip_file (self):
+    def test_unzip_file(self):
         self.archive_extract('p.zip.foo', check=None)
         self.archive_list('p.zip.foo')
         self.archive_test('p.zip.foo')

--- a/tests/archives/test_zip.py
+++ b/tests/archives/test_zip.py
@@ -21,7 +21,7 @@ class TestZip (ArchiveTest):
     program = 'zip'
 
     @needs_program(program)
-    def test_zip (self):
+    def test_zip(self):
         self.archive_create('t.zip')
         self.archive_test('t.zip')
         self.archive_create('t.cbz')
@@ -35,7 +35,7 @@ class TestZip (ArchiveTest):
 
     @needs_program('file')
     @needs_program(program)
-    def test_zip_file (self):
+    def test_zip_file(self):
         self.archive_test('t.zip.foo')
         self.archive_test('t.cbz.foo')
         self.archive_test('t.apk.foo')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,12 +18,12 @@ import patoolib
 
 class TestConfiguration (unittest.TestCase):
 
-    def test_archive_mimetypes (self):
+    def test_archive_mimetypes(self):
         # test that each format has a MIME type
         self.assertEqual(set(patoolib.ArchiveFormats),
                          set(patoolib.ArchiveMimetypes.values()))
 
-    def test_archive_programs (self):
+    def test_archive_programs(self):
         # test that the key is an archive format
         self.assertEqual(set(patoolib.ArchiveFormats),
                          set(patoolib.ArchivePrograms.keys()))
@@ -32,16 +32,16 @@ class TestConfiguration (unittest.TestCase):
                 if command is not None:
                     self.assertTrue(command in patoolib.ArchiveCommands)
 
-    def test_compression_programs (self):
+    def test_compression_programs(self):
         self.assertTrue(set(patoolib.ArchiveCompressions).issubset(
                          set(patoolib.ArchiveFormats)))
 
-    def test_encoding_mimes (self):
+    def test_encoding_mimes(self):
         self.assertEqual(set(patoolib.ArchiveCompressions),
                          set(patoolib.util.Encoding2Mime.keys()))
         for mime in patoolib.util.Encoding2Mime.values():
             self.assertTrue(mime in patoolib.ArchiveMimetypes)
 
-    def test_filetext_mime (self):
+    def test_filetext_mime(self):
         for mime in patoolib.util.FileText2Mime.values():
             self.assertTrue(mime in patoolib.ArchiveMimetypes)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -24,7 +24,7 @@ class ArchiveDiffTest (unittest.TestCase):
     @needs_program('diff')
     @needs_program('tar')
     @needs_program('unzip')
-    def test_diff (self):
+    def test_diff(self):
         archive1 = os.path.join(datadir, "t.tar")
         archive2 = os.path.join(datadir, "t.zip")
         run_checked([sys.executable, patool_cmd, "-vv", "--non-interactive", "diff", archive1, archive2])

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -20,5 +20,5 @@ from . import patool_cmd
 
 class TestFormats (unittest.TestCase):
 
-    def test_list_formats (self):
+    def test_list_formats(self):
         run_checked([sys.executable, patool_cmd, "-vv", "--non-interactive", 'formats'])

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -21,7 +21,7 @@ from . import needs_program, datadir
 
 class TestMime (unittest.TestCase):
 
-    def mime_test (self, func, filename, mime, encoding):
+    def mime_test(self, func, filename, mime, encoding):
         """Test that file has given mime and encoding as determined by
         given function."""
         archive = os.path.join(datadir, filename)
@@ -33,18 +33,18 @@ class TestMime (unittest.TestCase):
             self.assertEqual(file_mime, mime, fail_msg % ("MIME type", filename, mime, file_mime))
         self.assertEqual(file_encoding, encoding, fail_msg % ("Encoding", filename, encoding, file_encoding))
 
-    def mime_test_file (self, filename, mime, encoding=None):
+    def mime_test_file(self, filename, mime, encoding=None):
         """Test that file has given mime and encoding as determined by
         file(1)."""
         self.mime_test(patoolib.util.guess_mime_file, filename, mime, encoding)
 
-    def mime_test_mimedb (self, filename, mime, encoding=None):
+    def mime_test_mimedb(self, filename, mime, encoding=None):
         """Test that file has given mime and encoding as determined by the
         mimetypes module."""
         self.mime_test(patoolib.util.guess_mime_mimedb, filename, mime, encoding)
 
     @needs_program('file')
-    def test_mime_file (self):
+    def test_mime_file(self):
         self.mime_test_file("t .7z", "application/x-7z-compressed")
         self.mime_test_file("t .cb7", "application/x-7z-compressed")
         self.mime_test_file("t.cb7.foo", "application/x-7z-compressed")
@@ -141,39 +141,39 @@ class TestMime (unittest.TestCase):
 
     @needs_program('file')
     @needs_program('lzip')
-    def test_mime_file_lzip (self):
+    def test_mime_file_lzip(self):
         self.mime_test_file("t.tar.lz.foo", "application/x-tar", "lzip")
 
     @needs_program('file')
     @needs_program('bzip2')
-    def test_mime_file_bzip (self):
+    def test_mime_file_bzip(self):
         self.mime_test_file("t.tar.bz2.foo", "application/x-tar", "bzip2")
         self.mime_test_file("t.tbz2.foo", "application/x-tar", "bzip2")
 
     @needs_program('file')
-    def test_nested_gzip (self):
+    def test_nested_gzip(self):
         # Ensure that a file that doesn't natively support encoding does not see the encoding
         self.mime_test_file("t.rar.gz", "application/gzip")
         self.mime_test_file("t.rar.gz.foo", "application/gzip")
 
     @needs_program('file')
     @needs_program('gzip')
-    def test_mime_file_gzip (self):
+    def test_mime_file_gzip(self):
         self.mime_test_file("t.tar.gz.foo", "application/x-tar", "gzip")
         self.mime_test_file("t.taz.foo", "application/x-tar", "gzip")
         self.mime_test_file("t.tgz.foo", "application/x-tar", "gzip")
 
     @needs_program('file')
     @needs_program('xz')
-    def test_mime_file_xzip (self):
+    def test_mime_file_xzip(self):
         self.mime_test_file("t.tar.xz.foo", "application/x-tar", "xz")
 
     @needs_program('file')
     @needs_program('uncompress')
-    def test_mime_file_compress (self):
+    def test_mime_file_compress(self):
         self.mime_test_file("t.tar.Z.foo", "application/x-tar", "compress")
 
-    def test_mime_mimedb (self):
+    def test_mime_mimedb(self):
         self.mime_test_mimedb("t .7z", "application/x-7z-compressed")
         self.mime_test_mimedb("t .cb7", "application/x-7z-compressed")
         self.mime_test_mimedb("t.arj", "application/x-arj")

--- a/tests/test_recompress.py
+++ b/tests/test_recompress.py
@@ -35,6 +35,6 @@ class ArchiveRecompressTest (unittest.TestCase):
                 os.remove(tmpfile)
 
     @needs_one_program(('zip', '7z'))
-    def test_repack (self):
+    def test_repack(self):
         self.recompress('t.zip')
 

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -36,16 +36,16 @@ class ArchiveRepackTest (unittest.TestCase):
     @needs_program('diff')
     @needs_one_program(('tar', 'star', '7z'))
     @needs_one_program(('zip', '7z'))
-    def test_repack (self):
+    def test_repack(self):
         self.repack('t.tar', 't.zip')
 
     @needs_program('diff')
     @needs_one_program(('gzip', '7z'))
     @needs_one_program(('bzip2', '7z'))
-    def test_repack_same_format_different_compression (self):
+    def test_repack_same_format_different_compression(self):
         self.repack('t.tar.gz', 't.tar.bz2')
 
     @needs_program('diff')
-    def test_repack_same_format (self):
+    def test_repack_same_format(self):
         self.repack('t.tar.gz', 't1.tar.gz')
         self.repack('t.zip', 't1.zip')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,19 +19,19 @@ from patoolib import util
 
 class UtilTest (unittest.TestCase):
 
-    def test_samefile1 (self):
+    def test_samefile1(self):
         filename1 = filename2 = __file__
         self.assertTrue(util.is_same_filename(filename1, filename2))
         self.assertTrue(util.is_same_file(filename1, filename2))
 
-    def test_samefile2 (self):
+    def test_samefile2(self):
         parentdir = os.path.dirname(__file__)
         filename1 = os.path.dirname(parentdir)
         filename2 = os.path.join(parentdir, '..')
         self.assertTrue(util.is_same_filename(filename1, filename2))
         self.assertTrue(util.is_same_file(filename1, filename2))
 
-    def test_samefile3 (self):
+    def test_samefile3(self):
         parentdir = os.path.dirname(__file__)
         filename1 = os.path.dirname(parentdir)
         filename2 = os.path.join(parentdir, '.')


### PR DESCRIPTION
I checked that all such spaces are completely removed using:

find . -name '*.py' -exec grep -H def\ .*\ \( {} \;