### PR TITLE
Enable archive header encryption for 7z

### DIFF
--- a/patoolib/programs/p7zip.py
+++ b/patoolib/programs/p7zip.py
@@ -15,9 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Archive commands for the 7z program."""
 
-def _maybe_add_password(cmdlist, password):
+def _maybe_add_password(cmdlist, password, is_creating_7z=False):
     if password:
-        cmdlist.append('-p%s' % password)
+        if is_creating_7z:
+            cmdlist.extend(['-p%s' % password, '-mhe=on'])
+        else:
+            cmdlist.append('-p%s' % password)
 
 def extract_7z(archive, compression, cmd, verbosity, interactive, outdir, password=None):
     """Extract a 7z archive."""
@@ -114,7 +117,7 @@ def create_7z(archive, compression, cmd, verbosity, interactive, filenames, pass
     cmdlist = [cmd, 'a']
     if not interactive:
         cmdlist.append('-y')
-    _maybe_add_password(cmdlist, password)
+    _maybe_add_password(cmdlist, password, is_creating_7z=True)
     cmdlist.extend(['-t7z', '-mx=9', '--', archive])
     cmdlist.extend(filenames)
     return cmdlist


### PR DESCRIPTION
This enables archive header encryption when creating 7z archives with a password.

From the man page:

```
-mhe=on|off
    7z format only : enables or disables archive header encryption (Default : off)
```

Without this switch set to `on`, the archive contents will still be visible (e.g., using `patool list`), even if a password is set (which is probably not desirable for most use cases).

__Without `-mhe=on` (current patool behavior):__
```bash
➜  patool list test_without_mhe_on.7z 
patool: Listing test_without_mhe_on.7z ...
patool: ... cmdlist_func = <function list_7z at 0x7efd6fba5ee0> 
patool: ... kwargs={'password': None} args=('test_without_mhe_on.7z', None, '/usr/bin/7z', 1, True)
patool: running /usr/bin/7z l -- test_without_mhe_on.7z

7-Zip [64] 17.04 : Copyright (c) 1999-2021 Igor Pavlov : 2017-08-28
p7zip Version 17.04 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,32 CPUs x64)

Scanning the drive for archives:
1 file, 90 bytes (1 KiB)

Listing archive: test_without_mhe_on.7z

--
Path = test_without_mhe_on.7z
Type = 7z
Physical Size = 90
Headers Size = 90
Solid = -
Blocks = 0

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2021-05-01 23:10:14 ....A            0            0  test.txt
------------------- ----- ------------ ------------  ------------------------
2021-05-01 23:10:14                  0            0  1 files
```

__With `-mhe=on`:__
```bash
➜  patool list test_with_mhe_on.7z  
patool: Listing test_with_mhe_on.7z ...
patool: ... cmdlist_func = <function list_7z at 0x7f2016b1cee0> 
patool: ... kwargs={'password': None} args=('test_with_mhe_on.7z', None, '/usr/bin/7z', 1, True)
patool: running /usr/bin/7z l -- test_with_mhe_on.7z

7-Zip [64] 17.04 : Copyright (c) 1999-2021 Igor Pavlov : 2017-08-28
p7zip Version 17.04 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,32 CPUs x64)

Scanning the drive for archives:
1 file, 142 bytes (1 KiB)

Listing archive: test_with_mhe_on.7z


Enter password (will not be echoed):
```
After entering the password, it correctly lists the archive contents.