### PR TITLE
Fix `_diff_archives` cleanup

### DIFF
--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -668,8 +668,10 @@ def _diff_archives (archive1, archive2, verbosity=0, interactive=True):
             path2 = _extract_archive(archive2, outdir=tmpdir2, verbosity=-1)
             return util.run_checked([diff, "-urN", path1, path2], verbosity=1, ret_ok=(0, 1))
         finally:
+            make_user_readable(tmpdir2)
             shutil.rmtree(tmpdir2, onerror=rmtree_log_error)
     finally:
+        make_user_readable(tmpdir1)
         shutil.rmtree(tmpdir1, onerror=rmtree_log_error)
 
 


### PR DESCRIPTION
tmpdir should be deleted `finally` even if you compare archives that contains read-only files.