### PR TITLE
Fix Windows tar doesn't use --force-local

### DIFF
--- a/patoolib/programs/tar.py
+++ b/patoolib/programs/tar.py
@@ -44,6 +44,8 @@ def create_tar (archive, compression, cmd, verbosity, interactive, filenames):
 def add_tar_opts (cmdlist, compression, verbosity):
     """Add tar options to cmdlist."""
     progname = os.path.basename(cmdlist[0])
+    if progname[-4:].lower() == '.exe':
+        progname = progname[:-4]
     if compression == 'gzip':
         cmdlist.append('-z')
     elif compression == 'compress':


### PR DESCRIPTION
On Windows, the `--force-local` is required due to there is always a `:` in the path.
- https://github.com/wummel/patool/issues/42
- https://github.com/wummel/patool/pull/60

But "progname" is "tar.EXE" on my Windows PC so [if progname == "tar":](https://github.com/wummel/patool/blob/4928f3fc5083248ec83bbf6b02b5d9089c309100/patoolib/programs/tar.py#L63) condition is never met. This commit fix that by always removing trailing `.exe`.

```
patool: Extracting C:\Users\jfcherng\AppData\Local\Temp\XXX.tar.gz ...
patool: ... cmdlist_func = <function extract_tar at 0x000001DCD6F7E840>
patool: ... kwargs={'password': None} args=('C:\\Users\\jfcherng\\AppData\\Local\\Temp\\XXX.tar.gz', 'gzip', 'C:\\Program Files\\Git\\usr\\bin\\tar.EXE', 0, False, 'C:\\Users\\jfcherng\\AppData\\Local\\Temp')
patool: running "C:\Program Files\Git\usr\bin\tar.EXE" --extract -z --file C:\Users\jfcherng\AppData\Local\Temp\XXX.tar.gz --directory C:\Users\jfcherng\AppData\Local\Temp
```

By the way, the executable on my PC is actually `tar.exe` but Python's `shutil.which('tar')` returns `"C:\Program Files\Git\usr\bin\tar.EXE"`. Since filename on Windows is case-insensitive, it works.