### PR TITLE
Disable sandbox for file(1) to allow correct output for compressed tar's

### DIFF
--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -240,7 +240,7 @@ def guess_mime_file (filename):
                 encoding = None
     if mime in Mime2Encoding:
         # try to look inside compressed archives
-        cmd = [file_prog, "--brief", "--mime", "--uncompress", filename]
+        cmd = [file_prog, "--brief", "--mime", "--uncompress", "--no-sandbox", filename]
         try:
             outparts = backtick(cmd).strip().split(";")
             mime2 = outparts[0].split(" ", 1)[0]


### PR DESCRIPTION
* Otherwise file(1) will refuse with "Fork-is-required-to-uncompress--but-disabled"

Closes: https://github.com/wummel/patool/issues/75


```
$ file --brief --mime --uncompress tests/data/t.tar.gz
application/x-decompression-error-zlib-Fork-is-required-to-uncompress--but-disabled compressed-encoding=application/gzip; charset=binary
$ file --brief --mime --uncompress --no-sandbox tests/data/t.tar.gz
application/x-tar; charset=binary compressed-encoding=application/gzip; charset=binary
$ file --brief --mime --uncompress tests/data/t.taz
application/x-decompression-error-zlib-Fork-is-required-to-uncompress--but-disabled compressed-encoding=application/gzip; charset=binary
$ file --brief --mime --uncompress --no-sandbox tests/data/t.taz
application/x-tar; charset=binary compressed-encoding=application/gzip; charset=binary
$ file --brief --mime --uncompress tests/data/t.tgz
application/x-decompression-error-zlib-Fork-is-required-to-uncompress--but-disabled compressed-encoding=application/gzip; charset=binary
$ file --brief --mime --uncompress --no-sandbox tests/data/t.tgz
application/x-tar; charset=binary compressed-encoding=application/gzip; charset=binary
```

Applies to bzip and so on as well.

This shouldn't break this for anybody else as [Debian Buster packages 5.35](https://packages.debian.org/buster/file) which supports this flag.

```
FAILED tests/test_mime.py::TestMime::test_mime_file - AssertionError: 'application/x-bzip2' != 'application/x-tar'
FAILED tests/test_mime.py::TestMime::test_mime_file_bzip - AssertionError: 'application/x-bzip2' != 'application/x-tar'
FAILED tests/test_mime.py::TestMime::test_mime_file_compress - AssertionError: 'application/x-compress' != 'application/x-tar'
FAILED tests/test_mime.py::TestMime::test_mime_file_gzip - AssertionError: 'application/gzip' != 'application/x-tar'
FAILED tests/test_mime.py::TestMime::test_mime_file_lzip - AssertionError: 'application/x-lzip' != 'application/x-tar'
FAILED tests/test_mime.py::TestMime::test_mime_file_xzip - AssertionError: 'application/x-xz' != 'application/x-tar'
FAILED tests/test_mime.py::TestMime::test_mime_file_zstd - AssertionError: 'application/zstd' != 'application/x-tar'
FAILED tests/test_repack.py::ArchiveRepackTest::test_repack_same_format - patoolib.util.PatoolError: Command `['/var/tmp/portage/app-arch/patool-1.12_p20230424/work/patool-ab64562c8cdac34dfd69fcb6e30c8c001428...
FAILED tests/test_repack.py::ArchiveRepackTest::test_repack_same_format_different_compression - patoolib.util.PatoolError: Command `['/var/tmp/portage/app-arch/patool-1.12_p20230424/work/patool-ab64562c8cdac34dfd69fcb6e30c8c001428...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_bz2 - patoolib.util.PatoolError: could not find list_bzip2 in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1.12...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_bz2_file - patoolib.util.PatoolError: could not find list_bzip2 in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1.12...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_gz - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1.12_...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_gz_file - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1.12_...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_xz_file - patoolib.util.PatoolError: could not find list_xz in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1.12_p2...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_z - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1.12_...
FAILED tests/archives/test_bsdtar.py::TestBsdtar::test_bsdtar_z_file - patoolib.util.PatoolError: could not find list_compress in <module 'patoolib.programs.bsdtar' from '/var/tmp/portage/app-arch/patool-1...
FAILED tests/archives/test_pytarfile.py::TestPytarfile::test_py_tarfile_bz2 - patoolib.util.PatoolError: could not find list_bzip2 in <module 'patoolib.programs.py_tarfile' from '/var/tmp/portage/app-arch/patool-...
FAILED tests/archives/test_pytarfile.py::TestPytarfile::test_py_tarfile_bz2_file - patoolib.util.PatoolError: could not find list_bzip2 in <module 'patoolib.programs.py_tarfile' from '/var/tmp/portage/app-arch/patool-...
FAILED tests/archives/test_pytarfile.py::TestPytarfile::test_py_tarfile_gz - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.py_tarfile' from '/var/tmp/portage/app-arch/patool-1...
FAILED tests/archives/test_pytarfile.py::TestPytarfile::test_py_tarfile_gz_file - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.py_tarfile' from '/var/tmp/portage/app-arch/patool-1...
FAILED tests/archives/test_tar.py::TestTar::test_tar_bz2 - patoolib.util.PatoolError: could not find list_bzip2 in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p2...
FAILED tests/archives/test_tar.py::TestTar::test_tar_bz2_file - patoolib.util.PatoolError: could not find list_bzip2 in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p2...
FAILED tests/archives/test_tar.py::TestTar::test_tar_gz - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p20...
FAILED tests/archives/test_tar.py::TestTar::test_tar_gz_file - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p20...
FAILED tests/archives/test_tar.py::TestTar::test_tar_lzip_file - patoolib.util.PatoolError: could not find list_lzip in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p20...
FAILED tests/archives/test_tar.py::TestTar::test_tar_xz_file - patoolib.util.PatoolError: could not find list_xz in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p2023...
FAILED tests/archives/test_tar.py::TestTar::test_tar_z - patoolib.util.PatoolError: could not find list_gzip in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12_p20...
FAILED tests/archives/test_tar.py::TestTar::test_tar_z_file - patoolib.util.PatoolError: could not find list_compress in <module 'patoolib.programs.tar' from '/var/tmp/portage/app-arch/patool-1.12...
```

This patch fixes all of the above.