### PR TITLE
Include test data in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include MANIFEST.in
 include COPYING doc/*.1 doc/*.txt doc/icon/*
 include Makefile *.bash-completion
 include scripts/*.bat
-recursive-include tests *.py
+graft tests


### PR DESCRIPTION
Sdists uploaded to pypi don't have the tests but no test data, so it isn't very useful. This change includes everything in the tests dir so that tests could succeed if used from an sdist.