### PR TITLE
Fixing command line output in list_archive() method

### DIFF
--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -743,8 +743,10 @@ def extract_archive(archive, verbosity=0, outdir=None, program=None, interactive
     return _extract_archive(archive, verbosity=verbosity, interactive=interactive, outdir=outdir, program=program, password=password)
 
 
-def list_archive(archive, verbosity=1, program=None, interactive=True, password=None):
+def list_archive(archive, verbosity=2, program=None, interactive=True, password=None):
+
     """List given archive."""
+    # update : setting verbosity to 2 only on list_archive function to display what comes out from the command line
     # Set default verbosity to 1 since the listing output should be visible.
     fileutil.check_existing_filename(archive)
     if verbosity >= 0:

--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -746,8 +746,8 @@ def extract_archive(archive, verbosity=0, outdir=None, program=None, interactive
 def list_archive(archive, verbosity=2, program=None, interactive=True, password=None):
 
     """List given archive."""
-    # update : setting verbosity to 2 only on list_archive function to display what comes out from the command line
     # Set default verbosity to 1 since the listing output should be visible.
+    # Update : setting verbosity to 2 only on list_archive function to display what comes out from the command line.
     fileutil.check_existing_filename(archive)
     if verbosity >= 0:
         log.log_info(f"Listing {archive} ...")

--- a/patoolib/cli.py
+++ b/patoolib/cli.py
@@ -54,8 +54,10 @@ def run_list(args):
     for archive in args.archive:
         try:
             # increase default verbosity since the listing output should be visible
-            verbosity = args.verbosity + 1
-            list_archive(archive, verbosity=verbosity, interactive=args.interactive, password=args.password)
+
+            # changing verbosity to a hard-coded 2 for list_archive function
+            # verbosity = args.verbosity + 1
+            list_archive(archive, verbosity=2, interactive=args.interactive, password=args.password)
         except PatoolError as msg:
             log_error(f"error listing {archive}: {msg}")
             res += 1

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -90,7 +90,8 @@ def run(cmd, verbosity=0, **kwargs):
     
     res = subprocess.run(cmd, **kwargs)
     # display what comes out from subprocess.run here
-    # I need to stdout in a variable for later use
+    # we can use regex to get the exact file info without unneccesary output
+    # this only prints if list_archive is called.
     if verbosity == 2:
         print(res.stdout.decode())
 

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -90,8 +90,10 @@ def run(cmd, verbosity=0, **kwargs):
     
     res = subprocess.run(cmd, **kwargs)
     # display what comes out from subprocess.run here
+    # I need to stdout in a variable for later use
     if verbosity == 2:
         print(res.stdout.decode())
+
     return res.returncode
 
 

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -81,10 +81,17 @@ def run(cmd, verbosity=0, **kwargs):
         if kwargs.get("shell"):
             # for shell calls the command must be a string
             cmd = " ".join(cmd)
-    if verbosity < 1:
+    if verbosity == 1:
         # hide command output on stdout
         kwargs['stdout'] = subprocess.DEVNULL
+    elif verbosity == 2:
+        # only list_archive function sets verbosity to 2
+        kwargs["stdout"] = subprocess.PIPE
+    
     res = subprocess.run(cmd, **kwargs)
+    # display what comes out from subprocess.run here
+    if verbosity == 2:
+        print(res.stdout.decode())
     return res.returncode
 
 

--- a/test.py
+++ b/test.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from patoolib import cli
 
 cli.main(["extract", r"C:\Users\Quakeguy\Desktop\2.zip"])
-# rarfile = Path(r"C:\Users\Quakeguy\Desktop\1.rar")
-# zipfile = Path(r"C:\Users\Quakeguy\Desktop\2.zip")
+rarfile = Path(r"C:\Users\Quakeguy\Desktop\1.rar")
+zipfile = Path(r"C:\Users\Quakeguy\Desktop\2.zip")
 
-# patoolib.extract_archive(str(rarfile))
+patoolib.extract_archive(str(rarfile))
+patoolib.list_archive(str(rarfile))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,9 @@
+import patoolib
+from pathlib import Path
+from patoolib import cli
+
+cli.main(["extract", r"C:\Users\Quakeguy\Desktop\2.zip"])
+# rarfile = Path(r"C:\Users\Quakeguy\Desktop\1.rar")
+# zipfile = Path(r"C:\Users\Quakeguy\Desktop\2.zip")
+
+# patoolib.extract_archive(str(rarfile))


### PR DESCRIPTION
The `list_archive` method doesn't display the command line output, whether by using the library or the command line (`patool list <file_to_path>`)

OS: Windows 10.0.19045
IDE: VSCode 1.85.0

You need to remove `subprocess.DEVNULL` in the `run` method, but this will display what comes out from the output everytime your run any function (even `extract_archive()`).

To fix this, I set the `verbosity` to 2 in the `list_archive()` method and two conditions in the `run` method, one to change stdout in the `subprocess.run` from `DEVNULL` to `PIPE` (More explanations in the comments), and another one to display the output only when `list_archive` is called.

Both `patoolib.py` and `cli.py` are both fixed and works perfectly.
This is my first contribution, I hope this is a good fix for the issue, but if you have a better fix, I'd love to see how more experienced programmers solve their problems.
 