### PR TITLE
Missing f-string in __init__.py

### DIFF
--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -605,7 +605,7 @@ def list_formats():
         for command in ArchiveCommands:
             programs = ArchivePrograms[format]
             if command not in programs and None not in programs:
-                print("   {command:>8}: - (not supported)")
+                print(f"   {command:>8}: - (not supported)")
                 continue
             try:
                 program = find_archive_program(format, command)


### PR DESCRIPTION
Given the rest of the print statement, there seems to be a missing string format specifier when we do not support a command for an archive type.