### PR TITLE
Use file(1) for detecting ALZ archives

### DIFF
--- a/patoolib/mime.py
+++ b/patoolib/mime.py
@@ -168,10 +168,6 @@ def guess_mime_file(filename: str) -> tuple[str | None, str | None]:
     @return: tuple (mime, encoding)
     """
     mime, encoding = None, None
-    base, ext = os.path.splitext(filename)
-    if ext.lower() in ('.alz',):
-        # let mimedb recognize these extensions
-        return mime, encoding
     if os.path.isfile(filename):
         file_prog = find_program("file")
         if file_prog:
@@ -246,6 +242,7 @@ def get_file_mime_encoding(parts: Sequence[str]) -> str | None:
 FileText2Mime: dict[str, str] = {
     "7-zip archive data": "application/x-7z-compressed",
     "ACE archive data": "application/x-ace",
+    "ALZ archive data": "application/x-alzip",
     "Amiga DOS disk": "application/x-adf",
     "ARJ archive data": "application/x-arj",
     "bzip2 compressed data": "application/x-bzip2",

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -137,9 +137,8 @@ class TestMime(unittest.TestCase):
         self.mime_test_file("t.lha", "application/x-lha")
         self.mime_test_file("t.lzh", "application/x-lha")
         self.mime_test_file("t.lha.foo", "application/x-lha")
-        # file(1) does not recognize .alz files
-        # self.mime_test_file("t.alz", "application/x-alzip")
-        # self.mime_test_file("t.alz.foo", "application/x-alzip")
+        self.mime_test_file("t.alz", "application/x-alzip")
+        self.mime_test_file("t.alz.foo", "application/x-alzip")
         self.mime_test_file("t.arc", "application/x-arc")
         self.mime_test_file("t.arc.foo", "application/x-arc")
         self.mime_test_file("t.txt.lz4", "application/x-lz4")


### PR DESCRIPTION
libmagic 5.40 added support for detecting it, no unique mime though.

debian buster has 5.34 and debian bullseye has 5.39, so merging would break tests for them.

```
$ file --brief tests/data/t.alz
ALZ archive data
$ file --mime tests/data/t.alz
tests/data/t.alz: application/octet-stream; charset=binary
```