### PR TITLE
Detect .pyw scripts in run_under_pythonw()

### DIFF
--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -41,7 +41,7 @@ def run_under_pythonw() -> bool:
     return (
         os.name == 'nt'
         and sys.executable is not None
-        and sys.executable.lower().endswith('pythonw.exe')
+        and (sys.executable.lower().endswith('pythonw.exe') or sys.argv[0].lower().endswith(".pyw"))
     )
 
 


### PR DESCRIPTION
The run_under_pythonw() logic only detects pythonw.exe as a GUI environment. This fails for .pyw scripts executed with python.exe, requiring users to manually patch the detection logic to include the flag.

This changes now checks if the user is either running pythonw or if the script ends with pyw.
With this change the user does not need to create a patch anymore to activate the flag, he only needs to rename the python script extension to pyw 