### PR TITLE
Expand rar detection logic to all 7zip programs

### DIFF
--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -610,7 +610,11 @@ def find_archive_program(
             return program
         exe = util.find_program(program)
         if exe:
-            if program == '7z' and format == 'rar' and not util.p7zip_supports_rar():
+            if (
+                program in ('7z', '7zz', '7zzs')
+                and format == 'rar'
+                and not util.p7zip_supports_rar(program)
+            ):
                 continue
             if not check_program_compression(
                 command, program, exe, compression, verbosity=verbosity
@@ -717,7 +721,7 @@ def list_formats() -> None:
                             end=' ',
                         )
                 elif format == '7z':
-                    if util.p7zip_supports_rar():
+                    if util.p7zip_supports_rar(program):
                         print("(rar archives supported)", end=' ')
                     else:
                         print("(rar archives not supported)", end=' ')

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -112,7 +112,7 @@ def shell_quote_nt(value: str) -> str:
     return value
 
 
-def p7zip_supports_rar() -> bool:
+def p7zip_supports_rar(program: str) -> bool:
     """Determine if the RAR codec is installed for 7z program.
     If installed, `7z i` will print something like
     ...
@@ -123,7 +123,7 @@ def p7zip_supports_rar() -> bool:
     1   D    40305 Rar5
     ...
     """
-    _7z = find_program("7z")
+    _7z = find_program(program)
     if _7z:
         formats = backtick([_7z, "i"])
         return bool(re.search(r" Rar\d$", formats, re.MULTILINE))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -102,10 +102,8 @@ def needs_codec(program, codec, commands=patoolib.ArchiveCommands):
 
 def has_codec(command, program, exe, codec):
     """Test if program supports given codec with given command."""
-    if program == '7z' and codec == 'rar':
-        # On Debian, the non-free p7zip-rar package must be installed to support RAR
-        return patoolib.util.p7zip_supports_rar()
-    if program in ('7zz', '7zzs') and codec == 'rar':
-        # the 7-Zip program directly supports RAR
-        return True
+    if program in ('7z', '7zz', '7zzs') and codec == 'rar':
+        # 7zip can be optionally built without rar support
+        # Notably on Debian, the non-free p7zip-rar package must be installed to support RAR for 7z
+        return patoolib.util.p7zip_supports_rar(program)
     return patoolib.program_supports_compression(command, program, exe, codec)


### PR DESCRIPTION
All 7zip programs can be built without rar support. p7zip is just notable in that Debian builds it without rar by default. Gentoo for example allows the user to control this as they wish for both 7z (app-arch/p7zip) and 7zz (app-arch/7zip).

<details>
<summary>Failing test results from tests/archives/test_7zz.py with app-arch/7zip[-rar] before this change</summary>

```
(patoool-test) ask@bigglane /home/ask/sources/patool $ python -m pytest tests/archives/test_7zz.py
============================================== test session starts ===============================================
platform linux -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/ask/sources/patool
configfile: pyproject.toml
collected 8 items                                                                                                

tests/archives/test_7zz.py ..FF..FF                                                                        [100%]

==================================================== FAILURES ====================================================
______________________________________________ Test7zz.test_7zz_rar ______________________________________________

args = (<tests.archives.test_7zz.Test7zz testMethod=test_7zz_rar>,), kwargs = {}, exe = '/usr/bin/7zz'
command = 'create'

    def newfunc(*args, **kwargs):
        exe = patoolib.util.find_program(program)
        if not exe:
            pytest.skip(f"program `{program}' not available")
        for command in commands:
            if not has_codec(command, program, exe, codec):
                pytest.skip(
                    f"codec `{codec}' for program `{program}' and command `{command}' not available"
                )
>       return f(*args, **kwargs)

tests/__init__.py:95: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/archives/test_7zz.py:82: in test_7zz_rar
    self.archive_extract('t.rar')
tests/archives/__init__.py:77: in archive_extract
    self._archive_extract(archive, check)
tests/archives/__init__.py:91: in _archive_extract
    output = patoolib.extract_archive(
patoolib/__init__.py:1140: in extract_archive
    return _extract_archive(
patoolib/__init__.py:856: in _extract_archive
    run_archive_cmdlist(cmdlist, verbosity=verbosity)
patoolib/__init__.py:782: in run_archive_cmdlist
    return util.run_checked(cmdlist, verbosity=verbosity, **runkwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cmd = ['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7', ...]
ret_ok = (0,), kwargs = {'verbosity': 0}, retcode = 2
msg = "Command `['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7', '--', '/home/ask/sources/patool/tests/data/t.rar']' returned non-zero exit status 2"

    def run_checked(cmd: Sequence[str], ret_ok: Sequence[int] = (0,), **kwargs) -> int:
        """Run command and raise PatoolError on error."""
        retcode = run(cmd, **kwargs)
        if retcode not in ret_ok:
            msg = f"Command `{cmd}' returned non-zero exit status {retcode}"
>           raise PatoolError(msg)
E           patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7', '--', '/home/ask/sources/patool/tests/data/t.rar']' returned non-zero exit status 2

patoolib/util.py:87: PatoolError
---------------------------------------------- Captured stdout call ----------------------------------------------

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 110 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/t.rar

--
Path = /home/ask/sources/patool/tests/data/t.rar
Type = Rar
Physical Size = 110
Solid = -
Blocks = 2
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:48:58 .....            2           11  t/t.txt
2010-02-19 07:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:49:56                  2           11  1 files, 1 folders

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 110 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/t.rar

--
Path = /home/ask/sources/patool/tests/data/t.rar
Type = Rar
Physical Size = 110
Solid = -
Blocks = 2
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:48:58 .....            2           11  t/t.txt
2010-02-19 07:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:49:56                  2           11  1 files, 1 folders
---------------------------------------------- Captured stderr call ----------------------------------------------
INFO patool: Listing /home/ask/sources/patool/tests/data/t.rar ...
INFO patool: archive /home/ask/sources/patool/tests/data/t.rar has mime application/vnd.rar and compression None
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/t.rar
INFO patool: running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/t.rar ...
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/t.rar
INFO patool: running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/t.rar ...
INFO patool: running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar
INFO patool: Extracting /home/ask/sources/patool/tests/data/t.rar ...
INFO patool: running /usr/bin/7zz x -y -p- -aou -o/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7 -- /home/ask/sources/patool/tests/data/t.rar
ERROR: Unsupported Method : t/t.txt
ERROR patool: extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7'
----------------------------------------------- Captured log call ------------------------------------------------
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/t.rar ...
INFO     patool:log.py:66 archive /home/ask/sources/patool/tests/data/t.rar has mime application/vnd.rar and compression None
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/t.rar
INFO     patool:log.py:66 running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/t.rar ...
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/t.rar
INFO     patool:log.py:66 running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/t.rar ...
INFO     patool:log.py:66 running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar
INFO     patool:log.py:66 Extracting /home/ask/sources/patool/tests/data/t.rar ...
INFO     patool:log.py:66 running /usr/bin/7zz x -y -p- -aou -o/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7 -- /home/ask/sources/patool/tests/data/t.rar
ERROR    patool:log.py:56 extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_479g0tub/Unpack_yz2wvmq7'
___________________________________________ Test7zz.test_7zz_rar_file ____________________________________________

args = (<tests.archives.test_7zz.Test7zz testMethod=test_7zz_rar_file>,), kwargs = {}

    def newfunc(*args, **kwargs):
        if not testfunc(name):
            pytest.skip(f"{description} {name!r} is not available")
>       return func(*args, **kwargs)

tests/__init__.py:44: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/__init__.py:95: in newfunc
    return f(*args, **kwargs)
tests/archives/test_7zz.py:137: in test_7zz_rar_file
    self.archive_extract(self.filename + '.rar.foo')
tests/archives/__init__.py:77: in archive_extract
    self._archive_extract(archive, check)
tests/archives/__init__.py:91: in _archive_extract
    output = patoolib.extract_archive(
patoolib/__init__.py:1140: in extract_archive
    return _extract_archive(
patoolib/__init__.py:856: in _extract_archive
    run_archive_cmdlist(cmdlist, verbosity=verbosity)
patoolib/__init__.py:782: in run_archive_cmdlist
    return util.run_checked(cmdlist, verbosity=verbosity, **runkwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cmd = ['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu', ...]
ret_ok = (0,), kwargs = {'verbosity': 0}, retcode = 2
msg = "Command `['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu', '--', '/home/ask/sources/patool/tests/data/t.rar.foo']' returned non-zero exit status 2"

    def run_checked(cmd: Sequence[str], ret_ok: Sequence[int] = (0,), **kwargs) -> int:
        """Run command and raise PatoolError on error."""
        retcode = run(cmd, **kwargs)
        if retcode not in ret_ok:
            msg = f"Command `{cmd}' returned non-zero exit status {retcode}"
>           raise PatoolError(msg)
E           patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu', '--', '/home/ask/sources/patool/tests/data/t.rar.foo']' returned non-zero exit status 2

patoolib/util.py:87: PatoolError
---------------------------------------------- Captured stdout call ----------------------------------------------

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 110 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/t.rar.foo

--
Path = /home/ask/sources/patool/tests/data/t.rar.foo
Type = Rar
Physical Size = 110
Solid = -
Blocks = 2
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:48:58 .....            2           11  t/t.txt
2010-02-19 07:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:49:56                  2           11  1 files, 1 folders

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 110 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/t.rar.foo

--
Path = /home/ask/sources/patool/tests/data/t.rar.foo
Type = Rar
Physical Size = 110
Solid = -
Blocks = 2
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:48:58 .....            2           11  t/t.txt
2010-02-19 07:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 07:49:56                  2           11  1 files, 1 folders
---------------------------------------------- Captured stderr call ----------------------------------------------
INFO patool: Listing /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO patool: Different MIME types detected for /home/ask/sources/patool/tests/data/t.rar.foo: application/vnd.rar by file(1), None by extension. Preferring application/vnd.rar.
INFO patool: archive /home/ask/sources/patool/tests/data/t.rar.foo has mime application/vnd.rar and compression None
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/t.rar.foo
INFO patool: running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar.foo
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/t.rar.foo
INFO patool: running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar.foo
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO patool: running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar.foo
INFO patool: Extracting /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO patool: running /usr/bin/7zz x -y -p- -aou -o/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu -- /home/ask/sources/patool/tests/data/t.rar.foo
ERROR: Unsupported Method : t/t.txt
ERROR patool: extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu'
----------------------------------------------- Captured log call ------------------------------------------------
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO     patool:log.py:66 Different MIME types detected for /home/ask/sources/patool/tests/data/t.rar.foo: application/vnd.rar by file(1), None by extension. Preferring application/vnd.rar.
INFO     patool:log.py:66 archive /home/ask/sources/patool/tests/data/t.rar.foo has mime application/vnd.rar and compression None
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/t.rar.foo
INFO     patool:log.py:66 running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar.foo
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/t.rar.foo
INFO     patool:log.py:66 running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar.foo
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO     patool:log.py:66 running /usr/bin/7zz l -y -p- -- /home/ask/sources/patool/tests/data/t.rar.foo
INFO     patool:log.py:66 Extracting /home/ask/sources/patool/tests/data/t.rar.foo ...
INFO     patool:log.py:66 running /usr/bin/7zz x -y -p- -aou -o/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu -- /home/ask/sources/patool/tests/data/t.rar.foo
ERROR    patool:log.py:56 extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_s74tam1f/Unpack_cz824vvu'
__________________________________________ Test7zzPassword.test_7zz_rar __________________________________________

args = (<tests.archives.test_7zz.Test7zzPassword testMethod=test_7zz_rar>,), kwargs = {}, exe = '/usr/bin/7zz'
command = 'create'

    def newfunc(*args, **kwargs):
        exe = patoolib.util.find_program(program)
        if not exe:
            pytest.skip(f"program `{program}' not available")
        for command in commands:
            if not has_codec(command, program, exe, codec):
                pytest.skip(
                    f"codec `{codec}' for program `{program}' and command `{command}' not available"
                )
>       return f(*args, **kwargs)

tests/__init__.py:95: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/archives/test_7zz.py:159: in test_7zz_rar
    self.archive_extract('p.rar')
tests/archives/__init__.py:77: in archive_extract
    self._archive_extract(archive, check)
tests/archives/__init__.py:91: in _archive_extract
    output = patoolib.extract_archive(
patoolib/__init__.py:1140: in extract_archive
    return _extract_archive(
patoolib/__init__.py:856: in _extract_archive
    run_archive_cmdlist(cmdlist, verbosity=verbosity)
patoolib/__init__.py:782: in run_archive_cmdlist
    return util.run_checked(cmdlist, verbosity=verbosity, **runkwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cmd = ['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo', ...]
ret_ok = (0,), kwargs = {'verbosity': 0}, retcode = 2
msg = "Command `['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo', '--', '/home/ask/sources/patool/tests/data/p.rar']' returned non-zero exit status 2"

    def run_checked(cmd: Sequence[str], ret_ok: Sequence[int] = (0,), **kwargs) -> int:
        """Run command and raise PatoolError on error."""
        retcode = run(cmd, **kwargs)
        if retcode not in ret_ok:
            msg = f"Command `{cmd}' returned non-zero exit status {retcode}"
>           raise PatoolError(msg)
E           patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo', '--', '/home/ask/sources/patool/tests/data/p.rar']' returned non-zero exit status 2

patoolib/util.py:87: PatoolError
---------------------------------------------- Captured stdout call ----------------------------------------------

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 158 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/p.rar

--
Path = /home/ask/sources/patool/tests/data/p.rar
Type = Rar5
Physical Size = 158
Characteristics = Locator QuickOpen:0
Encrypted = -
Solid = -
Blocks = 2
Method = v6:128K:m5
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:48:58 .....            2           16  t/t.txt
2010-02-19 06:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:49:56                  2           16  1 files, 1 folders

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 158 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/p.rar

--
Path = /home/ask/sources/patool/tests/data/p.rar
Type = Rar5
Physical Size = 158
Characteristics = Locator QuickOpen:0
Encrypted = -
Solid = -
Blocks = 2
Method = v6:128K:m5
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:48:58 .....            2           16  t/t.txt
2010-02-19 06:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:49:56                  2           16  1 files, 1 folders
---------------------------------------------- Captured stderr call ----------------------------------------------
INFO patool: Listing /home/ask/sources/patool/tests/data/p.rar ...
INFO patool: archive /home/ask/sources/patool/tests/data/p.rar has mime application/vnd.rar and compression None
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/p.rar
INFO patool: running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/p.rar ...
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/p.rar
INFO patool: running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/p.rar ...
INFO patool: running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar
INFO patool: Extracting /home/ask/sources/patool/tests/data/p.rar ...
INFO patool: running /usr/bin/7zz x -y -pthereisnotry -aou -o/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo -- /home/ask/sources/patool/tests/data/p.rar
ERROR: Unsupported Method : t/t.txt
ERROR patool: extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo'
----------------------------------------------- Captured log call ------------------------------------------------
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/p.rar ...
INFO     patool:log.py:66 archive /home/ask/sources/patool/tests/data/p.rar has mime application/vnd.rar and compression None
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/p.rar
INFO     patool:log.py:66 running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/p.rar ...
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/p.rar
INFO     patool:log.py:66 running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/p.rar ...
INFO     patool:log.py:66 running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar
INFO     patool:log.py:66 Extracting /home/ask/sources/patool/tests/data/p.rar ...
INFO     patool:log.py:66 running /usr/bin/7zz x -y -pthereisnotry -aou -o/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo -- /home/ask/sources/patool/tests/data/p.rar
ERROR    patool:log.py:56 extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_n3dwo0g1/Unpack_1f1udgxo'
_______________________________________ Test7zzPassword.test_7zz_rar_file ________________________________________

args = (<tests.archives.test_7zz.Test7zzPassword testMethod=test_7zz_rar_file>,), kwargs = {}

    def newfunc(*args, **kwargs):
        if not testfunc(name):
            pytest.skip(f"{description} {name!r} is not available")
>       return func(*args, **kwargs)

tests/__init__.py:44: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/__init__.py:95: in newfunc
    return f(*args, **kwargs)
tests/archives/test_7zz.py:176: in test_7zz_rar_file
    self.archive_extract('p.rar.foo')
tests/archives/__init__.py:77: in archive_extract
    self._archive_extract(archive, check)
tests/archives/__init__.py:91: in _archive_extract
    output = patoolib.extract_archive(
patoolib/__init__.py:1140: in extract_archive
    return _extract_archive(
patoolib/__init__.py:856: in _extract_archive
    run_archive_cmdlist(cmdlist, verbosity=verbosity)
patoolib/__init__.py:782: in run_archive_cmdlist
    return util.run_checked(cmdlist, verbosity=verbosity, **runkwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cmd = ['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y', ...]
ret_ok = (0,), kwargs = {'verbosity': 0}, retcode = 2
msg = "Command `['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y', '--', '/home/ask/sources/patool/tests/data/p.rar.foo']' returned non-zero exit status 2"

    def run_checked(cmd: Sequence[str], ret_ok: Sequence[int] = (0,), **kwargs) -> int:
        """Run command and raise PatoolError on error."""
        retcode = run(cmd, **kwargs)
        if retcode not in ret_ok:
            msg = f"Command `{cmd}' returned non-zero exit status {retcode}"
>           raise PatoolError(msg)
E           patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y', '--', '/home/ask/sources/patool/tests/data/p.rar.foo']' returned non-zero exit status 2

patoolib/util.py:87: PatoolError
---------------------------------------------- Captured stdout call ----------------------------------------------

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 158 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/p.rar.foo

--
Path = /home/ask/sources/patool/tests/data/p.rar.foo
Type = Rar5
Physical Size = 158
Characteristics = Locator QuickOpen:0
Encrypted = -
Solid = -
Blocks = 2
Method = v6:128K:m5
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:48:58 .....            2           16  t/t.txt
2010-02-19 06:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:49:56                  2           16  1 files, 1 folders

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576

Scanning the drive for archives:
1 file, 158 bytes (1 KiB)

Listing archive: /home/ask/sources/patool/tests/data/p.rar.foo

--
Path = /home/ask/sources/patool/tests/data/p.rar.foo
Type = Rar5
Physical Size = 158
Characteristics = Locator QuickOpen:0
Encrypted = -
Solid = -
Blocks = 2
Method = v6:128K:m5
Multivolume = -
Volumes = 1

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:48:58 .....            2           16  t/t.txt
2010-02-19 06:49:56 D....            0            0  t
------------------- ----- ------------ ------------  ------------------------
2010-02-19 06:49:56                  2           16  1 files, 1 folders
---------------------------------------------- Captured stderr call ----------------------------------------------
INFO patool: Listing /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO patool: Different MIME types detected for /home/ask/sources/patool/tests/data/p.rar.foo: application/vnd.rar by file(1), None by extension. Preferring application/vnd.rar.
INFO patool: archive /home/ask/sources/patool/tests/data/p.rar.foo has mime application/vnd.rar and compression None
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/p.rar.foo
INFO patool: running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar.foo
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO patool: detected format rar for archive /home/ask/sources/patool/tests/data/p.rar.foo
INFO patool: running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar.foo
INFO patool:     with input=''
INFO patool: Listing /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO patool: running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar.foo
INFO patool: Extracting /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO patool: running /usr/bin/7zz x -y -pthereisnotry -aou -o/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y -- /home/ask/sources/patool/tests/data/p.rar.foo
ERROR: Unsupported Method : t/t.txt
ERROR patool: extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y'
----------------------------------------------- Captured log call ------------------------------------------------
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO     patool:log.py:66 Different MIME types detected for /home/ask/sources/patool/tests/data/p.rar.foo: application/vnd.rar by file(1), None by extension. Preferring application/vnd.rar.
INFO     patool:log.py:66 archive /home/ask/sources/patool/tests/data/p.rar.foo has mime application/vnd.rar and compression None
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/p.rar.foo
INFO     patool:log.py:66 running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar.foo
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO     patool:log.py:66 detected format rar for archive /home/ask/sources/patool/tests/data/p.rar.foo
INFO     patool:log.py:66 running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar.foo
INFO     patool:log.py:66     with input=''
INFO     patool:log.py:66 Listing /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO     patool:log.py:66 running /usr/bin/7zz l -y -pthereisnotry -- /home/ask/sources/patool/tests/data/p.rar.foo
INFO     patool:log.py:66 Extracting /home/ask/sources/patool/tests/data/p.rar.foo ...
INFO     patool:log.py:66 running /usr/bin/7zz x -y -pthereisnotry -aou -o/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y -- /home/ask/sources/patool/tests/data/p.rar.foo
ERROR    patool:log.py:56 extraction error, could not remove temporary extraction directory /home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y: [Errno 39] Directory not empty: '/home/ask/sources/patool/tests/test_1wvjdf2u/Unpack_8ut1ke5y'
============================================ short test summary info =============================================
FAILED tests/archives/test_7zz.py::Test7zz::test_7zz_rar - patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/te...
FAILED tests/archives/test_7zz.py::Test7zz::test_7zz_rar_file - patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-p-', '-aou', '-o/home/ask/sources/patool/te...
FAILED tests/archives/test_7zz.py::Test7zzPassword::test_7zz_rar - patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/source...
FAILED tests/archives/test_7zz.py::Test7zzPassword::test_7zz_rar_file - patoolib.util.PatoolError: Command `['/usr/bin/7zz', 'x', '-y', '-pthereisnotry', '-aou', '-o/home/ask/source...
========================================== 4 failed, 4 passed in 2.73s ===========================================
```
</details>

<details>
<summary>Too much detail with comparing 7zip output with RAR disabled</summary>

From DOC/readme.txt in the 24.90 source tarball.
```
DISABLE_RAR=1
  removes whole RAR related code from compilation.

DISABLE_RAR_COMPRESS=1
  removes "not fully free" code of RAR decompression codecs from compilation.

RAR decompression codecs in 7-Zip code has some additional license restrictions, 
that can be treated as not fully compatible with free-software licenses.
DISABLE_RAR_COMPRESS=1 allows to exclude such "not-fully-free" RAR code from compilation.
if DISABLE_RAR_COMPRESS=1 is specified, 7-zip will not be able to decompress files 
from rar archives, but 7-zip still will be able to open rar archives to get list of 
files or to extract files that are stored without compression.
if DISABLE_RAR=1 is specified, 7-zip will not be able to work with RAR archives.
```

## Static build without disabling RAR
```
$ ./7zzs-rar  i

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576


Formats:
   C...F..........c.a.m+..  7z       7z            7 z BC AF ' 1C
    ......................  APFS     apfs img      offset=32 N X S B 00
    ......................  APM      apm           E R
    ......................  Ar       ar a deb udeb lib ! < a r c h > 0A
    ......................  Arj      arj           ` EA
    K.....O.....X.........  Base64   b64           
    ......O...............  COFF     obj           
    ...F..................  Cab      cab           M S C F 00 00 00 00
    ......................  Chm      chm chi chq chw I T S F 03 00 00 00 ` 00 00 00
    ......................  Compound msi msp doc xls ppt D0 CF 11 E0 A1 B1 1A E1
    ....M.................  Cpio     cpio          0 7 0 7 0  ||  C7 q  ||  q C7
    ......................  CramFS   cramfs        offset=16 C o m p r e s s e d 20 R O M F S
    .....G..B.............  Dmg      dmg           k o l y 00 00 00 04 00 00 02 00
    .........E............  ELF      elf            E L F
    ......................  Ext      ext ext2 ext3 ext4 img offset=1080 S EF
    ......................  FAT      fat img       offset=510 U AA
    ......................  FLV      flv           F L V 01
    ......................  GPT      gpt mbr       offset=512 E F I 20 P A R T 00 00 01 00
    ....M.................  HFS      hfs hfsx      offset=1024 B D  ||  H + 00 04  ||  H X 00 05
    ...F..................  Hxs      hxs hxi hxr hxq hxw lit I T O L I T L S 01 00 00 00 ( 00 00 00
    ......O...............  IHex     ihex          
    ......................  Iso      iso img       offset=32769 C D 0 0 1
    ......................  LP       lpimg img     offset=4096 g D l a 4 00 00 00
    ......................  Lzh      lzh lha       offset=2 - l h
    .......P..............  MBR      mbr           
    ....M....E............  MachO    macho         CE FA ED FE  ||  CF FA ED FE  ||  FE ED FA CE  ||  FE ED FA CF
    ......................  MsLZ     mslz          S Z D D 88 F0 ' 3 A
    ....M.................  Mub      mub           CA FE BA BE 00 00 00  ||  B9 FA F1 0E
    ......................  NTFS     ntfs img      offset=3 N T F S 20 20 20 20 00
    ...F.G................  Nsis     nsis          offset=4 EF BE AD DE N u l l s o f t I n s t
    .........E............  PE       exe dll sys   M Z
    ......................  Ppmd     pmd           8F AF AC 84
    ......................  QCOW     qcow qcow2 qcow2c Q F I FB 00 00 00
    ...F..................  Rar      rar r00       R a r ! 1A 07 00
    ...F..................  Rar5     rar r00       R a r ! 1A 07 01 00
    ......................  Rpm      rpm           ED AB EE DB
    K.....................  SWF      swf           F W S
    ....M.................  SWFc     swf (~.swf)   C W S  ||  Z W S
    ......................  Sparse   simg img      : FF & ED 01 00
    ......................  Split    001           
    ....M.................  SquashFS squashfs      h s q s  ||  s q s h  ||  s h s q  ||  q s h s
    .........E............  TE       te            V Z
    ...FM.................  UEFIc    scap          BD 86 f ; v 0D 0 @ B7 0E B5 Q 9E / C5 A0  ||  8B A6 < J # w FB H 80 = W 8C C1 FE C4 M  ||  B9 82 91 S B5 AB 91 C B6 9A E3 A9 C F7 / CC
    ...FM.................  UEFIf    uefif         offset=16 D9 T 93 z h 04 J D 81 CE 0B F6 17 D8 90 DF  ||  x E5 8C 8C = 8A 1C O 99 5 89 a 85 C3 - D3
    ....M.O...............  Udf      udf iso img   offset=32768 00 B E A 0 1 01 00  ||  01 C D 0 0 1
    ......................  VDI      vdi           offset=64  10 DA BE
    .....G................  VHD      vhd           c o n e c t i x 00 00
    ......................  VHDX     vhdx avhdx    v h d x f i l e
    ......................  VMDK     vmdk          K D M V
    ......................  Xar      xar pkg xip   x a r ! 00
    ......................  Z        z taz (.tar)  1F 9D
   CK.....................  bzip2    bz2 bzip2 tbz2 (.tar) tbz (.tar) B Z h
   CK.................m+..  gzip     gz gzip tgz (.tar) tpz (.tar) apk (.tar) 1F 8B 08
    K.....O...............  lzma     lzma          
    K.....................  lzma86   lzma86        
   C......O...LH......m+..  tar      tar ova       offset=257 u s t a r
   C.SN.......LH..c.a.m+..  wim      wim swm esd ppkg M S W I M 00 00 00
   CK.....................  xz       xz txz (.tar) FD 7 z X Z 00
   C...FMG........c.a.m+..  zip      zip z01 zipx jar xpi odt ods docx xlsx epub ipa apk appx P K 03 04  ||  P K 05 06  ||  P K 06 06  ||  P K 07 08 P K  ||  P K 0 0 P K
    K.....................  zstd     zst tzst (.tar) ( B5 / FD
   CK.....O.....XC........  Hash     sha256 sha512 sha384 sha224 sha3-256 sha1 sha md5 blake2sp xxh64 crc32 crc64 asc cksum 

Codecs:
   4ED   303011B BCJ2
    EDF  3030103 BCJ
    EDF  3030205 PPC
    EDF  3030401 IA64
    EDF  3030501 ARM
    EDF  3030701 ARMT
    EDF  3030805 SPARC
    EDF        A ARM64
    EDF        B RISCV
    EDF    20302 Swap2
    EDF    20304 Swap4
    ED     40202 BZip2
    ED         0 Copy
    ED     40109 Deflate64
    ED     40108 Deflate
    EDF        3 Delta
    ED        21 LZMA2
    ED     30101 LZMA
    ED     30401 PPMD
     D     40301 Rar1
     D     40302 Rar2
     D     40303 Rar3
     D     40305 Rar5
    EDF  6F10701 7zAES
    EDF  6F00181 AES256CBC

Hashers:
      4        1 CRC32
     16      208 MD5
     20      201 SHA1
     32        A SHA256
    256      231 SHA3-256
     48      222 SHA384
     64      223 SHA512
      8      211 XXH64
      8        4 CRC64
     32      202 BLAKE2sp
```


## Static build with DISABLE_RAR_COMPRESS=1 (what gentoo does with USE="-rar")
```
$ ./7zzs-rar-no-compress  i

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576


Formats:
   C...F..........c.a.m+..  7z       7z            7 z BC AF ' 1C
    ......................  APFS     apfs img      offset=32 N X S B 00
    ......................  APM      apm           E R
    ......................  Ar       ar a deb udeb lib ! < a r c h > 0A
    ......................  Arj      arj           ` EA
    K.....O.....X.........  Base64   b64           
    ......O...............  COFF     obj           
    ...F..................  Cab      cab           M S C F 00 00 00 00
    ......................  Chm      chm chi chq chw I T S F 03 00 00 00 ` 00 00 00
    ......................  Compound msi msp doc xls ppt D0 CF 11 E0 A1 B1 1A E1
    ....M.................  Cpio     cpio          0 7 0 7 0  ||  C7 q  ||  q C7
    ......................  CramFS   cramfs        offset=16 C o m p r e s s e d 20 R O M F S
    .....G..B.............  Dmg      dmg           k o l y 00 00 00 04 00 00 02 00
    .........E............  ELF      elf            E L F
    ......................  Ext      ext ext2 ext3 ext4 img offset=1080 S EF
    ......................  FAT      fat img       offset=510 U AA
    ......................  FLV      flv           F L V 01
    ......................  GPT      gpt mbr       offset=512 E F I 20 P A R T 00 00 01 00
    ....M.................  HFS      hfs hfsx      offset=1024 B D  ||  H + 00 04  ||  H X 00 05
    ...F..................  Hxs      hxs hxi hxr hxq hxw lit I T O L I T L S 01 00 00 00 ( 00 00 00
    ......O...............  IHex     ihex          
    ......................  Iso      iso img       offset=32769 C D 0 0 1
    ......................  LP       lpimg img     offset=4096 g D l a 4 00 00 00
    ......................  Lzh      lzh lha       offset=2 - l h
    .......P..............  MBR      mbr           
    ....M....E............  MachO    macho         CE FA ED FE  ||  CF FA ED FE  ||  FE ED FA CE  ||  FE ED FA CF
    ......................  MsLZ     mslz          S Z D D 88 F0 ' 3 A
    ....M.................  Mub      mub           CA FE BA BE 00 00 00  ||  B9 FA F1 0E
    ......................  NTFS     ntfs img      offset=3 N T F S 20 20 20 20 00
    ...F.G................  Nsis     nsis          offset=4 EF BE AD DE N u l l s o f t I n s t
    .........E............  PE       exe dll sys   M Z
    ......................  Ppmd     pmd           8F AF AC 84
    ......................  QCOW     qcow qcow2 qcow2c Q F I FB 00 00 00
    ...F..................  Rar      rar r00       R a r ! 1A 07 00
    ...F..................  Rar5     rar r00       R a r ! 1A 07 01 00
    ......................  Rpm      rpm           ED AB EE DB
    K.....................  SWF      swf           F W S
    ....M.................  SWFc     swf (~.swf)   C W S  ||  Z W S
    ......................  Sparse   simg img      : FF & ED 01 00
    ......................  Split    001           
    ....M.................  SquashFS squashfs      h s q s  ||  s q s h  ||  s h s q  ||  q s h s
    .........E............  TE       te            V Z
    ...FM.................  UEFIc    scap          BD 86 f ; v 0D 0 @ B7 0E B5 Q 9E / C5 A0  ||  8B A6 < J # w FB H 80 = W 8C C1 FE C4 M  ||  B9 82 91 S B5 AB 91 C B6 9A E3 A9 C F7 / CC
    ...FM.................  UEFIf    uefif         offset=16 D9 T 93 z h 04 J D 81 CE 0B F6 17 D8 90 DF  ||  x E5 8C 8C = 8A 1C O 99 5 89 a 85 C3 - D3
    ....M.O...............  Udf      udf iso img   offset=32768 00 B E A 0 1 01 00  ||  01 C D 0 0 1
    ......................  VDI      vdi           offset=64  10 DA BE
    .....G................  VHD      vhd           c o n e c t i x 00 00
    ......................  VHDX     vhdx avhdx    v h d x f i l e
    ......................  VMDK     vmdk          K D M V
    ......................  Xar      xar pkg xip   x a r ! 00
    ......................  Z        z taz (.tar)  1F 9D
   CK.....................  bzip2    bz2 bzip2 tbz2 (.tar) tbz (.tar) B Z h
   CK.................m+..  gzip     gz gzip tgz (.tar) tpz (.tar) apk (.tar) 1F 8B 08
    K.....O...............  lzma     lzma          
    K.....................  lzma86   lzma86        
   C......O...LH......m+..  tar      tar ova       offset=257 u s t a r
   C.SN.......LH..c.a.m+..  wim      wim swm esd ppkg M S W I M 00 00 00
   CK.....................  xz       xz txz (.tar) FD 7 z X Z 00
   C...FMG........c.a.m+..  zip      zip z01 zipx jar xpi odt ods docx xlsx epub ipa apk appx P K 03 04  ||  P K 05 06  ||  P K 06 06  ||  P K 07 08 P K  ||  P K 0 0 P K
    K.....................  zstd     zst tzst (.tar) ( B5 / FD
   CK.....O.....XC........  Hash     sha256 sha512 sha384 sha224 sha3-256 sha1 sha md5 blake2sp xxh64 crc32 crc64 asc cksum 

Codecs:
   4ED   303011B BCJ2
    EDF  3030103 BCJ
    EDF  3030205 PPC
    EDF  3030401 IA64
    EDF  3030501 ARM
    EDF  3030701 ARMT
    EDF  3030805 SPARC
    EDF        A ARM64
    EDF        B RISCV
    EDF    20302 Swap2
    EDF    20304 Swap4
    ED     40202 BZip2
    ED         0 Copy
    ED     40109 Deflate64
    ED     40108 Deflate
    EDF        3 Delta
    ED        21 LZMA2
    ED     30101 LZMA
    ED     30401 PPMD
    EDF  6F10701 7zAES
    EDF  6F00181 AES256CBC

Hashers:
      4        1 CRC32
     16      208 MD5
     20      201 SHA1
     32        A SHA256
    256      231 SHA3-256
     48      222 SHA384
     64      223 SHA512
      8      211 XXH64
      8        4 CRC64
     32      202 BLAKE2sp
```

```
$ diff <(./7zzs-rar i) <(./7zzs-rar-no-compress i)
89,92d88
<      D     40301 Rar1
<      D     40302 Rar2
<      D     40303 Rar3
<      D     40305 Rar5
```

## Static build with DISABLE_RAR=1 (no one does this as far as I know)

```
$ ./7zzs-rar-no  i

7-Zip (z) 24.09 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-11-29
 64-bit locale=en_GB.utf8 Threads:12 OPEN_MAX:1048576


Formats:
   C...F..........c.a.m+..  7z       7z            7 z BC AF ' 1C
    ......................  APFS     apfs img      offset=32 N X S B 00
    ......................  APM      apm           E R
    ......................  Ar       ar a deb udeb lib ! < a r c h > 0A
    ......................  Arj      arj           ` EA
    K.....O.....X.........  Base64   b64           
    ......O...............  COFF     obj           
    ...F..................  Cab      cab           M S C F 00 00 00 00
    ......................  Chm      chm chi chq chw I T S F 03 00 00 00 ` 00 00 00
    ......................  Compound msi msp doc xls ppt D0 CF 11 E0 A1 B1 1A E1
    ....M.................  Cpio     cpio          0 7 0 7 0  ||  C7 q  ||  q C7
    ......................  CramFS   cramfs        offset=16 C o m p r e s s e d 20 R O M F S
    .....G..B.............  Dmg      dmg           k o l y 00 00 00 04 00 00 02 00
    .........E............  ELF      elf            E L F
    ......................  Ext      ext ext2 ext3 ext4 img offset=1080 S EF
    ......................  FAT      fat img       offset=510 U AA
    ......................  FLV      flv           F L V 01
    ......................  GPT      gpt mbr       offset=512 E F I 20 P A R T 00 00 01 00
    ....M.................  HFS      hfs hfsx      offset=1024 B D  ||  H + 00 04  ||  H X 00 05
    ...F..................  Hxs      hxs hxi hxr hxq hxw lit I T O L I T L S 01 00 00 00 ( 00 00 00
    ......O...............  IHex     ihex          
    ......................  Iso      iso img       offset=32769 C D 0 0 1
    ......................  LP       lpimg img     offset=4096 g D l a 4 00 00 00
    ......................  Lzh      lzh lha       offset=2 - l h
    .......P..............  MBR      mbr           
    ....M....E............  MachO    macho         CE FA ED FE  ||  CF FA ED FE  ||  FE ED FA CE  ||  FE ED FA CF
    ......................  MsLZ     mslz          S Z D D 88 F0 ' 3 A
    ....M.................  Mub      mub           CA FE BA BE 00 00 00  ||  B9 FA F1 0E
    ......................  NTFS     ntfs img      offset=3 N T F S 20 20 20 20 00
    ...F.G................  Nsis     nsis          offset=4 EF BE AD DE N u l l s o f t I n s t
    .........E............  PE       exe dll sys   M Z
    ......................  Ppmd     pmd           8F AF AC 84
    ......................  QCOW     qcow qcow2 qcow2c Q F I FB 00 00 00
    ......................  Rpm      rpm           ED AB EE DB
    K.....................  SWF      swf           F W S
    ....M.................  SWFc     swf (~.swf)   C W S  ||  Z W S
    ......................  Sparse   simg img      : FF & ED 01 00
    ......................  Split    001           
    ....M.................  SquashFS squashfs      h s q s  ||  s q s h  ||  s h s q  ||  q s h s
    .........E............  TE       te            V Z
    ...FM.................  UEFIc    scap          BD 86 f ; v 0D 0 @ B7 0E B5 Q 9E / C5 A0  ||  8B A6 < J # w FB H 80 = W 8C C1 FE C4 M  ||  B9 82 91 S B5 AB 91 C B6 9A E3 A9 C F7 / CC
    ...FM.................  UEFIf    uefif         offset=16 D9 T 93 z h 04 J D 81 CE 0B F6 17 D8 90 DF  ||  x E5 8C 8C = 8A 1C O 99 5 89 a 85 C3 - D3
    ....M.O...............  Udf      udf iso img   offset=32768 00 B E A 0 1 01 00  ||  01 C D 0 0 1
    ......................  VDI      vdi           offset=64  10 DA BE
    .....G................  VHD      vhd           c o n e c t i x 00 00
    ......................  VHDX     vhdx avhdx    v h d x f i l e
    ......................  VMDK     vmdk          K D M V
    ......................  Xar      xar pkg xip   x a r ! 00
    ......................  Z        z taz (.tar)  1F 9D
   CK.....................  bzip2    bz2 bzip2 tbz2 (.tar) tbz (.tar) B Z h
   CK.................m+..  gzip     gz gzip tgz (.tar) tpz (.tar) apk (.tar) 1F 8B 08
    K.....O...............  lzma     lzma          
    K.....................  lzma86   lzma86        
   C......O...LH......m+..  tar      tar ova       offset=257 u s t a r
   C.SN.......LH..c.a.m+..  wim      wim swm esd ppkg M S W I M 00 00 00
   CK.....................  xz       xz txz (.tar) FD 7 z X Z 00
   C...FMG........c.a.m+..  zip      zip z01 zipx jar xpi odt ods docx xlsx epub ipa apk appx P K 03 04  ||  P K 05 06  ||  P K 06 06  ||  P K 07 08 P K  ||  P K 0 0 P K
    K.....................  zstd     zst tzst (.tar) ( B5 / FD
   CK.....O.....XC........  Hash     sha256 sha512 sha384 sha224 sha3-256 sha1 sha md5 blake2sp xxh64 crc32 crc64 asc cksum 

Codecs:
   4ED   303011B BCJ2
    EDF  3030103 BCJ
    EDF  3030205 PPC
    EDF  3030401 IA64
    EDF  3030501 ARM
    EDF  3030701 ARMT
    EDF  3030805 SPARC
    EDF        A ARM64
    EDF        B RISCV
    EDF    20302 Swap2
    EDF    20304 Swap4
    ED     40202 BZip2
    ED         0 Copy
    ED     40109 Deflate64
    ED     40108 Deflate
    EDF        3 Delta
    ED        21 LZMA2
    ED     30101 LZMA
    ED     30401 PPMD
    EDF  6F10701 7zAES
    EDF  6F00181 AES256CBC

Hashers:
      4        1 CRC32
     16      208 MD5
     20      201 SHA1
     32        A SHA256
    256      231 SHA3-256
     48      222 SHA384
     64      223 SHA512
      8      211 XXH64
      8        4 CRC64
```

```
$ diff <(./7zzs-rar i) <(./7zzs-rar-no i)
40,41d39
<     ...F..................  Rar      rar r00       R a r ! 1A 07 00
<     ...F..................  Rar5     rar r00       R a r ! 1A 07 01 00
89,92d86
<      D     40301 Rar1
<      D     40302 Rar2
<      D     40303 Rar3
<      D     40305 Rar5
106d99
<      32      202 BLAKE2sp
```

</details>