### PR TITLE
Expose format option to cli and python api

### DIFF
--- a/patoolib/__init__.py
+++ b/patoolib/__init__.py
@@ -1157,6 +1157,7 @@ def extract_archive(
     program: str | None = None,
     interactive: bool = True,
     password: str | None = None,
+    format: str | None = None,
 ) -> str:
     """Extract an archive file.
 
@@ -1187,6 +1188,8 @@ def extract_archive(
          Note that the password might be written to logs that keep track of your command line
          history. If an archive program does not support passwords this option is ignored by patool.
     :type password: str or None
+    :param format: If given, use this archive format instead of auto-detection.
+    :type format: str or None
     :raise patoolib.PatoolError: If an archive does not exist or is not a regular file, or on errors while
          extracting.
     :return: The directory where the archive has been extracted.
@@ -1202,6 +1205,7 @@ def extract_archive(
         outdir=outdir,
         program=program,
         password=password,
+        format=format,
     )
 
 
@@ -1211,6 +1215,7 @@ def list_archive(
     program: str | None = None,
     interactive: bool = True,
     password: str | None = None,
+    format: str | None = None,
 ) -> None:
     """List given archive.
 
@@ -1235,6 +1240,8 @@ def list_archive(
          Note that the password might be written to logs that keep track of your command line
          history. If an archive program does not support passwords this option is ignored by patool.
     :type password: str or None
+    :param format: If given, use this archive format instead of auto-detection.
+    :type format: str or None
     :raise patoolib.PatoolError: If an archive does not exist or is not a regular file, or on errors while
          listing.
     :return: None
@@ -1251,6 +1258,7 @@ def list_archive(
         interactive=interactive,
         program=program,
         password=password,
+        format=format,
     )
 
 
@@ -1260,6 +1268,7 @@ def test_archive(
     program: str | None = None,
     interactive: bool = True,
     password: str | None = None,
+    format: str | None = None,
 ) -> None:
     """Test given archive.
 
@@ -1284,6 +1293,8 @@ def test_archive(
          Note that the password might be written to logs that keep track of your command line
          history. If an archive program does not support passwords this option is ignored by patool.
     :type password: str or None
+    :param format: If given, use this archive format instead of auto-detection.
+    :type format: str or None
     :raise patoolib.PatoolError: If an archive does not exist or is not a regular file, or on errors while
          testing.
     :return: None
@@ -1299,6 +1310,7 @@ def test_archive(
         interactive=interactive,
         program=program,
         password=password,
+        format=format,
     )
     if verbosity >= 0:
         log.log_info("... tested ok.")
@@ -1312,6 +1324,7 @@ def create_archive(
     program: str | None = None,
     interactive: bool = True,
     password: str | None = None,
+    format: str | None = None,
 ) -> None:
     """Create given archive with given files.
 
@@ -1339,6 +1352,8 @@ def create_archive(
          Note that the password might be written to logs that keep track of your command line
          history. If an archive program does not support passwords this option is ignored by patool.
     :type password: str or None
+    :param format: If given, use this archive format instead of auto-detection.
+    :type format: str or None
     :raise patoolib.PatoolError: on errors while creating the archive
     :return: None
     :rtype: None
@@ -1354,6 +1369,7 @@ def create_archive(
         interactive=interactive,
         program=program,
         password=password,
+        format=format,
     )
     if verbosity >= 0:
         log.log_info(f"... {archive} created.")

--- a/patoolib/cli.py
+++ b/patoolib/cli.py
@@ -53,6 +53,7 @@ def run_extract(args: argparse.Namespace) -> int:
                 interactive=args.interactive,
                 outdir=args.outdir,
                 password=args.password,
+                format=args.format,
             )
         except PatoolError as msg:
             log_error(f"error extracting {archive}: {msg}")
@@ -74,6 +75,7 @@ def run_list(args: argparse.Namespace) -> int:
                 verbosity=verbosity,
                 interactive=args.interactive,
                 password=args.password,
+                format=args.format,
             )
         except PatoolError as msg:
             log_error(f"error listing {archive}: {msg}")
@@ -91,6 +93,7 @@ def run_test(args: argparse.Namespace) -> int:
                 verbosity=args.verbosity,
                 interactive=args.interactive,
                 password=args.password,
+                format=args.format,
             )
         except PatoolError as msg:
             log_error(f"error testing {archive}: {msg}")
@@ -108,6 +111,7 @@ def run_create(args: argparse.Namespace) -> int:
             verbosity=args.verbosity,
             interactive=args.interactive,
             password=args.password,
+            format=args.format,
         )
     except PatoolError as msg:
         log_error(f"error creating {args.archive}: {msg}")
@@ -236,16 +240,19 @@ def create_argparser() -> argparse.ArgumentParser:
     )
     parser_extract.add_argument('--outdir', help="output directory to extract to")
     parser_extract.add_argument('--password', help="password for encrypted files")
+    parser_extract.add_argument('--format', help="archive format (e.g., 7z, tar, rar) - auto detected if not provided")
     parser_extract.add_argument('archive', nargs='+', help="an archive file")
     # list
     parser_list = subparsers.add_parser(
         'list', help='list members or one or more archives'
     )
     parser_list.add_argument('--password', help="password for encrypted files")
+    parser_list.add_argument('--format', help="archive format (e.g., 7z, tar, rar) - auto detected if not provided")
     parser_list.add_argument('archive', nargs='+', help="an archive file")
     # create
     parser_create = subparsers.add_parser('create', help='create an archive')
     parser_create.add_argument('--password', help="password to encrypt files")
+    parser_create.add_argument('--format', help="archive format (e.g., 7z, tar, rar) - auto detected if not provided")
     parser_create.add_argument(
         'archive',
         help="the archive file; the file extension determines the archive program",
@@ -258,6 +265,7 @@ def create_argparser() -> argparse.ArgumentParser:
     # test
     parser_test = subparsers.add_parser('test', help='test an archive')
     parser_test.add_argument('--password', help="password for encrypted files")
+    parser_test.add_argument('--format', help="archive format (e.g., 7z, tar, rar) - auto detected if not provided")
     parser_test.add_argument('archive', nargs='+', help='an archive file')
     # repack
     parser_repack = subparsers.add_parser(


### PR DESCRIPTION
## Summary
This PR adds the ability to manually specify the archive format for extract, list, test, and create operations in both the CLI and Python API, bypassing automatic format detection.

```console
patool list archive --format 7z
```

## Problem
Patool relies on MIME type detection and file extension matching to determine archive format. When a file has an uncommon extension or no extension, patool may fail to detect the format even when I believe an underlying program (e.g. 7z) could handle it. This removes the need for the work around of renaming the file extension just to get it to work (e.g. `mv archive archive.7z`)
